### PR TITLE
feat(ministry-maps): optimize territory routes and distribute them across teams

### DIFF
--- a/apps/ministry-maps/src/app/features/territory/bo/territory/territory.bo.ts
+++ b/apps/ministry-maps/src/app/features/territory/bo/territory/territory.bo.ts
@@ -40,7 +40,14 @@ export class TerritoryBO {
 
     return territories$.pipe(
       switchMap(territories => {
-        const designationTerritories: DesignationTerritory[] = territories.map(t => {
+        // The batched Firestore "IN" fetch does not preserve request order; re-sort the
+        // fetched territories to match the caller's id order (i.e. the optimized route).
+        const orderIndex = new Map(territoriesIds.map((id, i) => [id, i]));
+        const orderedTerritories = [...territories].sort(
+          (a, b) => (orderIndex.get(a.id) ?? 0) - (orderIndex.get(b.id) ?? 0)
+        );
+
+        const designationTerritories: DesignationTerritory[] = orderedTerritories.map(t => {
           // This is not needed for the Designation Territory
           delete t['recentHistory'];
 

--- a/apps/ministry-maps/src/app/features/territory/components/territory-checkbox/territory-checkbox.component.scss
+++ b/apps/ministry-maps/src/app/features/territory/components/territory-checkbox/territory-checkbox.component.scss
@@ -143,3 +143,19 @@
     flex-flow: column nowrap;
   }
 }
+
+.territory-checkbox__route-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.4rem;
+  height: 1.4rem;
+  margin-right: 0.4rem;
+  padding: 0 0.35rem;
+  border-radius: 999px;
+  background-color: #45c06c;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  vertical-align: middle;
+}

--- a/apps/ministry-maps/src/app/features/territory/components/territory-checkbox/territory-checkbox.component.ts
+++ b/apps/ministry-maps/src/app/features/territory/components/territory-checkbox/territory-checkbox.component.ts
@@ -57,7 +57,12 @@ import { VisitOutcomeEnum } from '../../../../../models/enums/visit-outcome';
             />
             <!-- Address and Note -->
             <div class="flex flex-col gap-1">
-              <h3 class="territory-checkbox__title">{{ territory.address }}</h3>
+              <h3 class="territory-checkbox__title">
+                @if (orderIndex !== null) {
+                  <span class="territory-checkbox__route-badge" [style.background-color]="badgeColor || null">{{ orderIndex }}</span>
+                }
+                {{ territory.address }}
+              </h3>
               <span class="territory-checkbox__subtitle">{{ territory.note }}</span>
             </div>
           </div>
@@ -150,6 +155,14 @@ export class TerritoryCheckboxComponent implements ControlValueAccessor, OnInit 
 
   @Input()
   territory!: Territory;
+
+  /** Optional 1-based position in an optimized route; renders a numbered badge when set. */
+  @Input()
+  orderIndex: number | null = null;
+
+  /** Optional color for the numbered badge (the assigned pair's color). */
+  @Input()
+  badgeColor: string | null = null;
 
   get statusClass() {
     const prefix = 'territory-checkbox__indicator--';

--- a/apps/ministry-maps/src/app/features/territory/pages/assign-territories-page/assign-territories-page.component.html
+++ b/apps/ministry-maps/src/app/features/territory/pages/assign-territories-page/assign-territories-page.component.html
@@ -20,6 +20,121 @@
     />
   </div>
 
+  <!-- Team planning: capacity suggestion + distribution -->
+  <details class="assign-team-panel mt-3" open>
+    <summary>Equipe &amp; distribuição</summary>
+    <div class="flex flex-wrap gap-3 mt-2">
+      <label class="flex flex-col t-caption">Homens
+        <input type="number" min="0" name="men" [(ngModel)]="team.men" (ngModelChange)="recomputeSuggestion()" />
+      </label>
+      <label class="flex flex-col t-caption">Mulheres
+        <input type="number" min="0" name="women" [(ngModel)]="team.women" (ngModelChange)="recomputeSuggestion()" />
+      </label>
+      <label class="flex flex-col t-caption">Carros
+        <input type="number" min="0" name="cars" [(ngModel)]="team.cars" (ngModelChange)="recomputeSuggestion()" />
+      </label>
+      <label class="flex flex-col t-caption">Duração (min)
+        <input type="number" min="0" step="15" name="durationMin" [(ngModel)]="team.durationMin" (ngModelChange)="recomputeSuggestion()" />
+      </label>
+    </div>
+
+    <label class="assign-economize mt-2">
+      <input type="checkbox" name="economize" [(ngModel)]="team.economize" (ngModelChange)="onEconomizeChange()" />
+      Economizar carros (usar o mínimo, máx. 5 por carro)
+    </label>
+
+    @if (numGroups > 0 || groupUnplaced > 0) {
+      <p class="t-caption mt-2">Equipe: <strong>{{ groupText }}</strong> ({{ team.men + team.women }} pessoas)
+        @if (groupUnplaced) { <span class="assign-over"> · {{ groupUnplaced }} sem dupla</span> }
+      </p>
+    }
+
+    @if (suggestion && suggestion.suggestedTotal > 0) {
+      <p class="t-caption mt-1">
+        Sugestão: <strong>≈ {{ suggestion.suggestedTotal }} territórios</strong> (≈ {{ suggestion.perPair }}/grupo) ·
+        selecionados: <strong [class.assign-over]="selectionState === 'over'">{{ selectedTerritoriesModel.size }}</strong> / {{ suggestion.suggestedTotal }}
+      </p>
+      @if (selectionState === 'over') {
+        <button type="button" class="assign-trim-btn" (click)="trimToSuggested()">
+          Aparar para ≈ {{ suggestion.suggestedTotal }} (mais atrasados)
+        </button>
+      }
+    }
+    <div class="flex items-center flex-wrap gap-3 mt-3">
+      <button
+        type="button"
+        class="assign-optimize-btn"
+        [disabled]="selectedTerritoriesModel.size < 2 || numGroups < 1"
+        (click)="handleDistribute()">
+        Otimizar e distribuir
+      </button>
+      <button
+        type="button"
+        class="assign-auto-btn"
+        [disabled]="numGroups < 1 || team.cars < 1 || (suggestion?.suggestedTotal ?? 0) < 2"
+        (click)="handleAutoDistribute()"
+        title="Informe homens, mulheres e carros. Seleciona automaticamente os territórios mais atrasados e distribui entre os carros">
+        Distribuir automaticamente
+      </button>
+      @if (plan) {
+        <span class="t-caption">
+          ≈ {{ plan.totalKm }} km ·
+          @if (plan.carsLeftBehind > 0) {
+            <strong>usando {{ plan.effectiveCars }} de {{ plan.carsAvailable }} carros</strong> ({{ plan.carsLeftBehind }} de folga)
+          } @else {
+            {{ plan.effectiveCars }} carro(s)
+          }
+        </span>
+      }
+    </div>
+  </details>
+
+  <!-- Per-car distribution result -->
+  @if (plan) {
+    @if (plan.groupPlan.unplacedMen || plan.groupPlan.unplacedWomen) {
+      <p class="assign-warn mt-2">
+        {{ plan.groupPlan.unplacedMen }} homem(ns) e {{ plan.groupPlan.unplacedWomen }} mulher(es) sem dupla válida
+      </p>
+    }
+    @if (plan.seatWarning) {
+      <p class="assign-warn mt-2">
+        Faltam carros: precisa de {{ plan.carsNeeded }} carros para {{ plan.groupPlan.people }} pessoas (máx. 5/carro). Você tem {{ plan.carsAvailable }}.
+      </p>
+    }
+    @if (plan.carsLeftBehind > 0) {
+      <p class="t-caption mt-2">{{ plan.carsLeftBehind }} carro(s) de folga ({{ plan.effectiveCars }} bastam dentro do tempo).</p>
+    }
+    <div class="assign-pair-cards mt-3">
+      @for (car of plan.cars; track car.carIndex) {
+        <div class="assign-pair-card" [style.border-left-color]="carColor(car.carIndex)">
+          <div class="assign-pair-card__head">
+            <span class="assign-pair-dot" [style.background-color]="carColor(car.carIndex)"></span>
+            <strong>Carro {{ car.carIndex + 1 }}</strong>
+            <span class="t-caption">· {{ describeGroups(car) }} · {{ car.people }} pessoas</span>
+            @if (car.overCapacity) { <span class="assign-pair-nocar">sobrelotado</span> }
+            @if (car.noManWithWomen) { <span class="assign-pair-over">sem homem</span> }
+            @if (car.estMinutes > team.durationMin) { <span class="assign-pair-over">acima do tempo</span> }
+          </div>
+          <div class="assign-group-chips">
+            @for (grp of car.groups; track $index) {
+              <span class="assign-group-chip" [class.assign-group-chip--trio]="grp.kind === 'trio'">
+                {{ grp.kind === 'trio' ? 'Trio' : 'Dupla' }} {{ groupMakeup(grp) }}
+              </span>
+            }
+          </div>
+          <span class="t-caption">
+            {{ car.territories.length }} territórios (≈ {{ car.perGroupTerritories }}/dupla) · ≈ {{ car.totalKm }} km · ≈ {{ car.estMinutes }} min/dupla
+          </span>
+          <button type="button" class="assign-share-btn"
+                  [disabled]="isSharingCar !== null"
+                  (click)="shareForCar(car)">
+            {{ isSharingCar === car.carIndex ? 'Compartilhando…' : 'Compartilhar' }}
+          </button>
+        </div>
+      }
+    </div>
+  }
+
   <!-- Territories -->
   <form id='territory-form' (submit)='handleTerritoryFormSubmit()'>
     <div class='flex flex-col gap-5 mt-8 pb-56'>
@@ -27,6 +142,8 @@
         <kingdom-apps-territory-checkbox
           [territory]='territory'
           [name]='territory.id'
+          [orderIndex]='orderIndexOf(territory.id)'
+          [badgeColor]='carColorOf(territory.id)'
           [ngModel]='hasAlreadyBeenSelected(territory.id)'
           [disabled]='assignedTerritories.has(territory.id)'
           (ngModelChange)='handleTerritoryCheck($event, territory)'>

--- a/apps/ministry-maps/src/app/features/territory/pages/assign-territories-page/assign-territories-page.component.scss
+++ b/apps/ministry-maps/src/app/features/territory/pages/assign-territories-page/assign-territories-page.component.scss
@@ -1,0 +1,164 @@
+.assign-optimize-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid #45c06c;
+  color: #2f8a4c;
+  background: transparent;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}
+
+.assign-team-panel {
+  summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  input[type='number'] {
+    width: 5rem;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid #d7d7d7;
+    border-radius: 0.4rem;
+  }
+}
+
+.assign-over {
+  color: #ef4444;
+}
+
+.assign-trim-btn {
+  margin-top: 0.5rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 0.4rem;
+  border: 1px solid #f59e0b;
+  color: #b45309;
+  background: transparent;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.assign-pair-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.assign-pair-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid #e2e2e2;
+  border-left-width: 4px;
+  border-radius: 0.5rem;
+  background: #fafafa;
+
+  &__head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}
+
+.assign-pair-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.assign-pair-nocar {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #b45309;
+  background: #fef3c7;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+}
+
+.assign-share-btn {
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  padding: 0.3rem 0.9rem;
+  border-radius: 0.4rem;
+  border: 1px solid #45c06c;
+  color: #2f8a4c;
+  background: transparent;
+  font-weight: 600;
+  font-size: 0.8rem;
+  cursor: pointer;
+
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.assign-auto-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid #45c06c;
+  color: #fff;
+  background: #45c06c;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}
+
+.assign-pair-over {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #b91c1c;
+  background: #fee2e2;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+}
+
+.assign-warn {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #b45309;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 0.4rem;
+  padding: 0.4rem 0.6rem;
+}
+
+.assign-group-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin: 0.15rem 0;
+}
+
+.assign-group-chip {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #1f2937;
+  background: #eef2ff;
+  border: 1px solid #c7d2fe;
+  padding: 0.05rem 0.45rem;
+  border-radius: 999px;
+
+  &--trio {
+    color: #92400e;
+    background: #fef3c7;
+    border-color: #fde68a;
+  }
+}
+
+.assign-economize {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+
+  input { width: 1rem; height: 1rem; }
+}

--- a/apps/ministry-maps/src/app/features/territory/pages/assign-territories-page/assign-territories-page.component.ts
+++ b/apps/ministry-maps/src/app/features/territory/pages/assign-territories-page/assign-territories-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { finalize, Observable, of, shareReplay } from 'rxjs';
+import { finalize, Observable, of, shareReplay, take, tap } from 'rxjs';
 
 import {
   ConfirmDialogComponent,
@@ -34,6 +34,12 @@ import { createSendWhatsAppLink } from '../../../../shared/utils/share-utils';
 import { FormsModule } from '@angular/forms';
 import { TerritoryCheckboxComponent } from '../../components/territory-checkbox/territory-checkbox.component';
 import { AsyncPipe } from '@angular/common';
+import { TeamDistributionService, DistributionPlan, CarPlan } from '../../services/team-distribution.service';
+import { suggestCapacity, selectionStatus, SelectionStatus } from '../../services/capacity';
+import { formGroups, describeGroups, groupMakeup } from '../../services/pairing';
+
+/** Fallback average leg (km) used for the capacity suggestion before a route is computed. */
+const DEFAULT_AVG_LEG_KM = 2;
 
 @Component({
   selector: 'kingdom-apps-assign-territories-page',
@@ -67,6 +73,27 @@ export class AssignTerritoriesPageComponent implements OnInit {
   selectedTerritoriesModel = new Set<string>();
   assignedTerritories = new Set<string>();
 
+  // Route optimization + team distribution state
+  private territoryById = new Map<string, Territory>();
+  private orderIndexById = new Map<string, number>(); // territory id -> 1-based global route position
+  private carIndexById = new Map<string, number>(); // territory id -> 0-based car
+  optimizedOrder: string[] = []; // full route order (all cars flattened) for the "send all" FAB
+  plan: DistributionPlan | null = null; // per-car distribution after "Distribuir"
+  suggestion: { perPair: number; suggestedTotal: number } | null = null;
+  selectionState: SelectionStatus = 'under';
+  isSharingCar: number | null = null;
+  // Cached crew composition (recomputed only on team/selection change, not every CD cycle).
+  numGroups = 0;
+  groupText = '';
+  groupUnplaced = 0;
+  team = { men: 0, women: 0, cars: 0, durationMin: 120, economize: true };
+  /** Average minutes spent per visit. */
+  private readonly visitMin = 10;
+
+  readonly CAR_COLORS = ['#45c06c', '#3b82f6', '#f59e0b', '#ef4444', '#8b5cf6', '#14b8a6', '#ec4899', '#84cc16'];
+  readonly describeGroups = describeGroups;
+  readonly groupMakeup = groupMakeup;
+
   public sortFilterConfig = TERRITORY_SORT_FILTER_CONFIG;
 
   @ViewChild(SearchInputComponent)
@@ -76,7 +103,8 @@ export class AssignTerritoriesPageComponent implements OnInit {
     private readonly territoryRepository: TerritoryRepository,
     private readonly userState: UserStateService,
     private readonly territoryBO: TerritoryBO,
-    private readonly dialog: Dialog
+    private readonly dialog: Dialog,
+    private readonly distribution: TeamDistributionService
   ) {}
 
   ngOnInit(): void {
@@ -87,6 +115,7 @@ export class AssignTerritoriesPageComponent implements OnInit {
     this.cities = cities;
 
     this.fetchTerritories(id, firstCity);
+    this.recomputeSuggestion();
   }
 
   /**
@@ -101,8 +130,15 @@ export class AssignTerritoriesPageComponent implements OnInit {
 
   handleTerritoryFormSubmit() {
     this.assignedTerritories = new Set([...this.selectedTerritoriesModel, ...this.assignedTerritories]);
-    const selectedTerritories = [...this.selectedTerritoriesModel.values()];
+    // Use the optimized route order when it covers exactly the current selection; otherwise selection order.
+    const selectionIds = [...this.selectedTerritoriesModel.values()];
+    const selectedTerritories =
+      this.optimizedOrder.length === selectionIds.length &&
+      selectionIds.every(id => this.optimizedOrder.includes(id))
+        ? this.optimizedOrder
+        : selectionIds;
     this.selectedTerritoriesModel.clear();
+    this.invalidatePlan();
 
     // Loading Spinner on Button
     this.isCreatingAssignment = true;
@@ -174,6 +210,10 @@ export class AssignTerritoriesPageComponent implements OnInit {
       this.selectedTerritoriesModel.delete(territoryId);
     }
 
+    // Any selection change invalidates a previously computed distribution.
+    this.invalidatePlan();
+    this.recomputeSuggestion();
+
     if (value && importantAlert) {
       this.openConfirmAssignmentDialog(importantAlert).subscribe((result) => {
         if (!result) {
@@ -181,6 +221,151 @@ export class AssignTerritoriesPageComponent implements OnInit {
         }
       });
     }
+  }
+
+  /**
+   * Forms work groups (pairs/trios) from the crew, optimizes the selected territories,
+   * and distributes them into per-car clusters. Runs synchronously from loaded territories.
+   */
+  handleDistribute() {
+    const ids = [...this.selectedTerritoriesModel.values()];
+    if (ids.length < 2 || this.numGroups < 1) {
+      return; // need at least 2 territories and a crew that forms at least one pair/trio
+    }
+
+    const selected = ids
+      .map(id => this.territoryById.get(id))
+      .filter((t): t is Territory => !!t);
+
+    const plan = this.distribution.distribute(selected, {
+      men: this.team.men,
+      women: this.team.women,
+      cars: this.team.cars,
+      visitMin: this.visitMin,
+      durationMin: this.team.durationMin,
+      economize: this.team.economize,
+    });
+    this.plan = plan;
+
+    // Build the global route order + per-car maps for the numbered, colored preview.
+    this.orderIndexById.clear();
+    this.carIndexById.clear();
+    const flat: string[] = [];
+    plan.cars.forEach(car => {
+      car.territories.forEach(t => {
+        flat.push(t.id);
+        this.orderIndexById.set(t.id, flat.length);
+        this.carIndexById.set(t.id, car.carIndex);
+      });
+    });
+    this.optimizedOrder = flat;
+    this.recomputeSuggestion();
+  }
+
+  /** Re-run the distribution when the economize toggle flips (if a plan is showing). */
+  onEconomizeChange() {
+    if (this.plan) {
+      this.handleDistribute();
+    }
+  }
+
+  /**
+   * One-click distribution: auto-select the most-overdue territories (ordered by last
+   * visit) up to the suggested count for the current team, then optimize + distribute.
+   * Pool is the loaded territories for the active city (or all cities when "Todas").
+   */
+  handleAutoDistribute() {
+    this.recomputeSuggestion();
+    const target = this.suggestion?.suggestedTotal ?? 0;
+    if (target < 2) {
+      return;
+    }
+
+    // Pool = the territories currently VISIBLE (same city + filters the user sees), so the
+    // auto-selection matches what gets badged and never picks filtered-out ones (e.g. bible students).
+    this.filteredTerritories$.pipe(take(1)).subscribe(list => {
+      const stalest = [...list]
+        .filter(t => !this.assignedTerritories.has(t.id))
+        .sort((a, b) => (a.lastVisit?.getTime() ?? 0) - (b.lastVisit?.getTime() ?? 0)); // stalest first
+
+      // Pass 1: distribute the default-estimate count to learn the real average leg.
+      this.selectedTerritoriesModel = new Set(stalest.slice(0, target).map(t => t.id));
+      this.handleDistribute();
+
+      // Pass 2: the suggestion just refined using the real travel - if fewer territories
+      // actually fit the time budget, trim to that and redistribute so pairs stay in budget.
+      const refined = this.suggestion?.suggestedTotal ?? target;
+      if (refined >= 2 && refined < target) {
+        this.selectedTerritoriesModel = new Set(stalest.slice(0, refined).map(t => t.id));
+        this.handleDistribute();
+      }
+    });
+  }
+
+  recomputeSuggestion() {
+    // Compute the crew composition ONCE and cache it (the template reads the cached fields
+    // instead of calling formGroups on every change-detection cycle).
+    const gp = formGroups(this.team.men, this.team.women);
+    this.numGroups = gp.groups.length;
+    this.groupText = this.describeGroups(gp);
+    this.groupUnplaced = gp.unplacedMen + gp.unplacedWomen;
+    // Capacity scales with the number of work groups (pairs + trios), not raw headcount.
+    const avgLegKm = this.plan ? this.plan.avgLegKm : DEFAULT_AVG_LEG_KM;
+    this.suggestion = suggestCapacity({
+      pairs: Math.max(1, this.numGroups),
+      durationMin: this.team.durationMin,
+      avgLegKm,
+      visitMin: this.visitMin,
+    });
+    this.selectionState = selectionStatus(this.selectedTerritoriesModel.size, this.suggestion.suggestedTotal);
+  }
+
+  /** Trim the current selection to the suggested total, keeping the stalest (most overdue). */
+  trimToSuggested() {
+    const target = this.suggestion?.suggestedTotal ?? 0;
+    if (!target || this.selectedTerritoriesModel.size <= target) {
+      return;
+    }
+    const kept = [...this.selectedTerritoriesModel.values()]
+      .map(id => this.territoryById.get(id))
+      .filter((t): t is Territory => !!t)
+      .sort((a, b) => (a.lastVisit?.getTime() ?? 0) - (b.lastVisit?.getTime() ?? 0)) // stalest first
+      .slice(0, target);
+    this.selectedTerritoriesModel = new Set(kept.map(t => t.id));
+    this.invalidatePlan();
+    this.recomputeSuggestion();
+  }
+
+  /** Creates a designation for one car's cluster (in order) and shares it via WhatsApp. */
+  shareForCar(car: CarPlan) {
+    this.isSharingCar = car.carIndex;
+    const ids = car.territories.map(t => t.id);
+    this.territoryBO
+      .createDesignationForTerritories(ids)
+      .pipe(finalize(() => (this.isSharingCar = null)))
+      .subscribe(designation => this.shareDesignation(designation.id));
+  }
+
+  private invalidatePlan() {
+    this.optimizedOrder = [];
+    this.plan = null;
+    this.orderIndexById.clear();
+    this.carIndexById.clear();
+  }
+
+  /** 1-based position of a territory id in the optimized route, or null if not distributed yet. */
+  orderIndexOf(id: string): number | null {
+    return this.orderIndexById.get(id) ?? null;
+  }
+
+  /** Color of a territory's assigned car, or null when not distributed. */
+  carColorOf(id: string): string | null {
+    const c = this.carIndexById.get(id);
+    return c === undefined ? null : this.CAR_COLORS[c % this.CAR_COLORS.length];
+  }
+
+  carColor(carIndex: number): string {
+    return this.CAR_COLORS[carIndex % this.CAR_COLORS.length];
   }
 
   shareDesignation(designationId: string) {
@@ -195,10 +380,17 @@ export class AssignTerritoriesPageComponent implements OnInit {
 
   private fetchTerritories(congregationId: string, city: string) {
     // This is the object that will be iterated, since we can't iterate through formGroup.controls...
-    this.territories$ =
+    const source$ =
       city === ALL_OPTION
-        ? this.territoryRepository.getAllByCongregation(congregationId).pipe(shareReplay(1))
-        : this.territoryRepository.getAllByCongregationAndCities(congregationId, [city]).pipe(shareReplay(1));
+        ? this.territoryRepository.getAllByCongregation(congregationId)
+        : this.territoryRepository.getAllByCongregationAndCities(congregationId, [city]);
+
+    // Accumulate every loaded territory so the optimizer can resolve any selected
+    // id synchronously (selections can span cities; you can only select what you've loaded).
+    this.territories$ = source$.pipe(
+      tap(list => list.forEach(t => this.territoryById.set(t.id, t))),
+      shareReplay(1)
+    );
 
     this.filterTerritories();
   }

--- a/apps/ministry-maps/src/app/features/territory/services/capacity.spec.ts
+++ b/apps/ministry-maps/src/app/features/territory/services/capacity.spec.ts
@@ -1,0 +1,86 @@
+import { selectionStatus, suggestCapacity } from './capacity';
+
+describe('suggestCapacity', () => {
+  it('accounts for leg travel time between stops', () => {
+    const result = suggestCapacity({
+      pairs: 5,
+      durationMin: 120,
+      avgLegKm: 2,
+      visitMin: 10,
+      avgKmh: 30,
+    });
+    // legMin = 2/30*60 = 4, minutesPerStop = 14, perPair = floor(120/14) = 8
+    expect(result.perPair).toBe(8);
+    expect(result.suggestedTotal).toBe(40);
+  });
+
+  it('treats unknown leg distance (0) as no travel time', () => {
+    const result = suggestCapacity({
+      pairs: 5,
+      durationMin: 120,
+      avgLegKm: 0,
+      visitMin: 10,
+      avgKmh: 30,
+    });
+    // minutesPerStop = 10, perPair = floor(120/10) = 12
+    expect(result.perPair).toBe(12);
+    expect(result.suggestedTotal).toBe(60);
+  });
+
+  it('applies default visitMin/avgKmh when omitted', () => {
+    const result = suggestCapacity({ pairs: 3, durationMin: 120, avgLegKm: 2 });
+    expect(result.perPair).toBe(8);
+    expect(result.suggestedTotal).toBe(24);
+  });
+
+  it('returns zeros when the time budget is non-positive', () => {
+    expect(suggestCapacity({ pairs: 5, durationMin: 0, avgLegKm: 2 })).toEqual({
+      perPair: 0,
+      suggestedTotal: 0,
+    });
+  });
+
+  it('returns zeros when there are no pairs', () => {
+    expect(suggestCapacity({ pairs: 0, durationMin: 120, avgLegKm: 2 })).toEqual({
+      perPair: 0,
+      suggestedTotal: 0,
+    });
+  });
+
+  it('never suggests fewer than one territory per pair', () => {
+    const result = suggestCapacity({
+      pairs: 2,
+      durationMin: 5,
+      avgLegKm: 2,
+      visitMin: 10,
+      avgKmh: 30,
+    });
+    expect(result.perPair).toBe(1);
+    expect(result.suggestedTotal).toBe(2);
+  });
+});
+
+describe('selectionStatus', () => {
+  it('is ok exactly at the suggested total', () => {
+    expect(selectionStatus(22, 22)).toBe('ok');
+  });
+
+  it('is ok within +/-1 of the suggested total', () => {
+    expect(selectionStatus(21, 22)).toBe('ok');
+    expect(selectionStatus(23, 22)).toBe('ok');
+  });
+
+  it('is under when fewer than suggested (beyond tolerance)', () => {
+    expect(selectionStatus(18, 22)).toBe('under');
+  });
+
+  it('is over when more than suggested (beyond tolerance)', () => {
+    expect(selectionStatus(30, 22)).toBe('over');
+  });
+
+  it('treats a zero suggestion sensibly', () => {
+    expect(selectionStatus(0, 0)).toBe('ok');
+    expect(selectionStatus(1, 0)).toBe('ok');
+    expect(selectionStatus(2, 0)).toBe('over');
+  });
+});

--- a/apps/ministry-maps/src/app/features/territory/services/capacity.ts
+++ b/apps/ministry-maps/src/app/features/territory/services/capacity.ts
@@ -1,0 +1,42 @@
+// Preaching-day capacity estimator.
+const DEFAULT_VISIT_MIN = 10; // avg time at one household (talk/notes)
+const DEFAULT_AVG_KMH = 30; // avg urban driving speed across the tri-city area
+
+export interface CapacitySuggestion {
+  perPair: number; // territories one pair can cover within the budget (>=1)
+  suggestedTotal: number; // perPair * pairs
+}
+
+export function suggestCapacity(input: {
+  pairs: number;
+  durationMin: number; // time budget for the session (e.g. 120 for 2h)
+  avgLegKm: number; // average straight-line distance between consecutive stops on the current route (0 if unknown)
+  visitMin?: number; // default 10
+  avgKmh?: number; // default 30
+}): CapacitySuggestion {
+  const { pairs, durationMin, avgLegKm } = input;
+  const visitMin = input.visitMin ?? DEFAULT_VISIT_MIN;
+  const avgKmh = input.avgKmh ?? DEFAULT_AVG_KMH;
+
+  if (durationMin <= 0 || pairs <= 0) {
+    return { perPair: 0, suggestedTotal: 0 };
+  }
+
+  const legMin = avgLegKm > 0 ? (avgLegKm / avgKmh) * 60 : 0;
+  const minutesPerStop = visitMin + legMin;
+
+  const perPair =
+    minutesPerStop <= 0 ? 1 : Math.max(1, Math.floor(durationMin / minutesPerStop));
+  const suggestedTotal = perPair * pairs;
+
+  return { perPair, suggestedTotal };
+}
+
+export type SelectionStatus = 'under' | 'ok' | 'over';
+
+export function selectionStatus(selected: number, suggestedTotal: number): SelectionStatus {
+  if (Math.abs(selected - suggestedTotal) <= 1) {
+    return 'ok';
+  }
+  return selected < suggestedTotal ? 'under' : 'over';
+}

--- a/apps/ministry-maps/src/app/features/territory/services/pairing.spec.ts
+++ b/apps/ministry-maps/src/app/features/territory/services/pairing.spec.ts
@@ -1,0 +1,74 @@
+import { formGroups, describeGroups, groupMakeup } from './pairing';
+
+describe('formGroups', () => {
+  it('pairs everyone same-sex when counts are even', () => {
+    const p = formGroups(12, 8); // 6 MM + 4 WW
+    expect(p.pairs).toBe(10);
+    expect(p.trios).toBe(0);
+    expect(p.people).toBe(20);
+    expect(p.groups.every(g => g.label === 'MM' || g.label === 'WW')).toBe(true);
+  });
+
+  it('absorbs an odd man into an all-men trio when men-pairs exist', () => {
+    const p = formGroups(7, 8); // WW*4, MM*3 -> one MM becomes MMM
+    expect(p.pairs).toBe(6);
+    expect(p.trios).toBe(1);
+    expect(p.groups.filter(g => g.label === 'MMM')).toHaveLength(1);
+    expect(p.people).toBe(15);
+    expect(p.unplacedMen).toBe(0);
+  });
+
+  it('makes both a women-trio and a men-trio when both counts are odd', () => {
+    const p = formGroups(5, 5); // WW*2->1WW+1WWW ; MM*2->1MM+1MMM
+    expect(p.pairs).toBe(2);
+    expect(p.trios).toBe(2);
+    expect(p.groups.filter(g => g.label === 'WWW')).toHaveLength(1);
+    expect(p.groups.filter(g => g.label === 'MMM')).toHaveLength(1);
+  });
+
+  it('leaves a lone man unplaced when there is no other man (pairs are same-sex)', () => {
+    const p = formGroups(1, 2); // 1 WW pair; the single man cannot pair with a woman
+    expect(p.pairs).toBe(1);
+    expect(p.trios).toBe(0);
+    expect(p.groups.every(g => g.label === 'WW')).toBe(true);
+    expect(p.unplacedMen).toBe(1);
+  });
+
+  it('never forms a mixed group', () => {
+    for (let m = 0; m <= 12; m++) {
+      for (let w = 0; w <= 12; w++) {
+        const p = formGroups(m, w);
+        expect(p.groups.every(g => g.men === 0 || g.women === 0)).toBe(true);
+      }
+    }
+  });
+
+  it('reports a genuinely unpairable lone person', () => {
+    expect(formGroups(1, 0).unplacedMen).toBe(1);
+    expect(formGroups(0, 1).unplacedWomen).toBe(1);
+  });
+
+  it('never makes a man+woman pair', () => {
+    for (let m = 0; m <= 12; m++) {
+      for (let w = 0; w <= 12; w++) {
+        const p = formGroups(m, w);
+        expect(p.groups.some(g => g.kind === 'pair' && g.men === 1 && g.women === 1)).toBe(false);
+        // every person is either placed or explicitly unplaced (no one lost)
+        expect(p.people + p.unplacedMen + p.unplacedWomen).toBe(m + w);
+      }
+    }
+  });
+
+  it('describes the composition in PT-BR', () => {
+    expect(describeGroups({ pairs: 6, trios: 1 })).toBe('6 duplas + 1 trio');
+    expect(describeGroups({ pairs: 1, trios: 0 })).toBe('1 dupla');
+    expect(describeGroups({ pairs: 0, trios: 2 })).toBe('2 trios');
+  });
+
+  it('labels each group makeup by gender', () => {
+    expect(groupMakeup({ men: 2, women: 0 })).toBe('2H');
+    expect(groupMakeup({ men: 0, women: 2 })).toBe('2M');
+    expect(groupMakeup({ men: 3, women: 0 })).toBe('3H');
+    expect(groupMakeup({ men: 0, women: 3 })).toBe('3M');
+  });
+});

--- a/apps/ministry-maps/src/app/features/territory/services/pairing.ts
+++ b/apps/ministry-maps/src/app/features/territory/services/pairing.ts
@@ -1,0 +1,95 @@
+export type GroupKind = 'pair' | 'trio';
+
+export interface WorkGroup {
+  kind: GroupKind;
+  men: number;
+  women: number;
+  size: number; // 2 or 3
+  label: string; // 'MM' | 'WW' | 'WWW' | 'MMM' | 'WWM'
+}
+
+export interface GroupPlan {
+  groups: WorkGroup[];
+  pairs: number;
+  trios: number;
+  people: number; // people actually placed into groups
+  unplacedMen: number; // a lone man with no valid partner
+  unplacedWomen: number; // a lone woman with no valid partner
+}
+
+/**
+ * Forms preaching work groups from a headcount of men and women. Every group is
+ * SAME-SEX, because the working unit is a pair and a woman can never pair with a man:
+ *  - pairs are MM or WW,
+ *  - an odd count is absorbed into a same-sex trio (WWW or MMM),
+ *  - a lone person with no same-sex partner (a single man, or a single woman) is
+ *    reported as unplaced rather than forced into a mixed pair.
+ */
+export function formGroups(men: number, women: number): GroupPlan {
+  const menCount = Math.max(0, Math.floor(men) || 0);
+  const womenCount = Math.max(0, Math.floor(women) || 0);
+
+  const mk = (w: number, m: number): WorkGroup => {
+    const size = w + m;
+    return { kind: size === 3 ? 'trio' : 'pair', men: m, women: w, size, label: 'W'.repeat(w) + 'M'.repeat(m) };
+  };
+
+  let wwCount = Math.floor(womenCount / 2);
+  let mmCount = Math.floor(menCount / 2);
+  const wLeft = womenCount % 2;
+  const mLeft = menCount % 2;
+
+  let unplacedMen = 0;
+  let unplacedWomen = 0;
+  let makeWWW = 0;
+  let makeMMM = 0;
+
+  // A leftover woman joins an existing women-pair -> WWW (same-sex trio).
+  if (wLeft) {
+    if (wwCount > 0) {
+      makeWWW = 1;
+      wwCount -= 1;
+    } else {
+      unplacedWomen = 1; // only one woman, no women-pair to join
+    }
+  }
+
+  // A leftover man joins a men-pair -> MMM (same-sex trio); a lone man with no other men
+  // cannot be placed (he can't pair with a woman).
+  if (mLeft) {
+    if (mmCount > 0) {
+      makeMMM = 1;
+      mmCount -= 1;
+    } else {
+      unplacedMen = 1;
+    }
+  }
+
+  const groups: WorkGroup[] = [];
+  for (let i = 0; i < wwCount; i++) groups.push(mk(2, 0));
+  for (let i = 0; i < mmCount; i++) groups.push(mk(0, 2));
+  for (let i = 0; i < makeWWW; i++) groups.push(mk(3, 0));
+  for (let i = 0; i < makeMMM; i++) groups.push(mk(0, 3));
+
+  const pairs = groups.filter(g => g.kind === 'pair').length;
+  const trios = groups.filter(g => g.kind === 'trio').length;
+  const people = groups.reduce((sum, g) => sum + g.size, 0);
+
+  return { groups, pairs, trios, people, unplacedMen, unplacedWomen };
+}
+
+/** Makeup of a single group by gender, e.g. "2H", "2M", "1H+2M" (H=homem, M=mulher). */
+export function groupMakeup(group: { men: number; women: number }): string {
+  const parts: string[] = [];
+  if (group.men) parts.push(`${group.men}H`);
+  if (group.women) parts.push(`${group.women}M`);
+  return parts.join('+');
+}
+
+/** Short PT-BR summary like "6 duplas + 1 trio". */
+export function describeGroups(plan: { pairs: number; trios: number }): string {
+  const parts: string[] = [];
+  if (plan.pairs) parts.push(`${plan.pairs} ${plan.pairs === 1 ? 'dupla' : 'duplas'}`);
+  if (plan.trios) parts.push(`${plan.trios} ${plan.trios === 1 ? 'trio' : 'trios'}`);
+  return parts.join(' + ') || 'nenhuma dupla';
+}

--- a/apps/ministry-maps/src/app/features/territory/services/route-optimizer.service.spec.ts
+++ b/apps/ministry-maps/src/app/features/territory/services/route-optimizer.service.spec.ts
@@ -1,0 +1,37 @@
+import { RouteOptimizerService } from './route-optimizer.service';
+import { Territory, TerritoryIcon } from '../../../../models/territory';
+
+const T = (id: string, lat: number, lng: number, lastVisitMs?: number): Territory => ({
+  id,
+  city: 'X',
+  address: id,
+  note: '',
+  congregationId: 'c',
+  icon: TerritoryIcon.WOMAN,
+  geo: { lat, lng },
+  lastVisit: lastVisitMs != null ? new Date(lastVisitMs) : undefined,
+});
+
+describe('RouteOptimizerService', () => {
+  const svc = new RouteOptimizerService();
+
+  it('starts at the stalest and appends unlocated', () => {
+    const stale = T('stale', 1, 1, 1000);
+    const fresh = T('fresh', 0, 0, 9_000_000_000_000);
+    const mid = T('mid', 0.5, 0.5, 5_000_000_000_000);
+    const noGeo: Territory = { ...T('nogeo', 0, 0), geo: undefined };
+
+    const r = svc.optimize([fresh, mid, stale, noGeo]);
+
+    expect(r.ordered[0].id).toBe('stale'); // stalest pinned first
+    expect(r.unlocated.map(t => t.id)).toEqual(['nogeo']);
+    expect(r.totalKm).toBeGreaterThan(0);
+  });
+
+  it('returns a single located territory unchanged', () => {
+    const only = T('only', 0, 0, 1000);
+    const r = svc.optimize([only]);
+    expect(r.ordered.map(t => t.id)).toEqual(['only']);
+    expect(r.totalKm).toBe(0);
+  });
+});

--- a/apps/ministry-maps/src/app/features/territory/services/route-optimizer.service.ts
+++ b/apps/ministry-maps/src/app/features/territory/services/route-optimizer.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core';
+import { Territory } from '../../../../models/territory';
+import {
+  buildHaversineMatrix,
+  solveTour,
+  solveNearestNeighborTwoOpt,
+  HEURISTIC_MAX_N,
+  GeoPointLike,
+} from '../../../shared/route-optimizer';
+
+export interface OptimizeResult {
+  ordered: Territory[];
+  unlocated: Territory[];
+  totalKm: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RouteOptimizerService {
+  /**
+   * Orders the selected territories into a short driving path by straight-line
+   * distance, oriented to START at the stalest (most overdue) one. Territories
+   * without a cached `geo` are appended at the end, flagged as unlocated.
+   */
+  optimize(selected: Territory[]): OptimizeResult {
+    const located = selected.filter(t => t.geo);
+    const unlocated = selected.filter(t => !t.geo);
+
+    if (located.length <= 1) {
+      return { ordered: located, unlocated, totalKm: 0 };
+    }
+
+    // Orient the route to start at the stalest territory (index 0 is the pinned start).
+    // Missing lastVisit is treated as most stale (never visited).
+    const stalest = (t: Territory): number => (t.lastVisit ? t.lastVisit.getTime() : 0);
+    const byStalest = [...located].sort((a, b) => stalest(a) - stalest(b));
+
+    const points: GeoPointLike[] = byStalest.map(t => t.geo as GeoPointLike);
+    const matrix = buildHaversineMatrix(points);
+
+    const solver = points.length > HEURISTIC_MAX_N ? solveNearestNeighborTwoOpt : solveTour;
+    const { order, totalDistance } = solver({
+      durationMatrix: matrix,
+      distanceMatrix: matrix,
+      endpoint: 'open',
+    });
+
+    const ordered = order.map(i => byStalest[i]);
+    return { ordered, unlocated, totalKm: Math.round(totalDistance * 10) / 10 };
+  }
+}

--- a/apps/ministry-maps/src/app/features/territory/services/team-distribution.service.spec.ts
+++ b/apps/ministry-maps/src/app/features/territory/services/team-distribution.service.spec.ts
@@ -1,0 +1,80 @@
+import { TestBed } from '@angular/core/testing';
+import { TeamDistributionService } from './team-distribution.service';
+import { Territory, TerritoryIcon } from '../../../../models/territory';
+
+const T = (id: string, lat: number, lng: number, geo = true): Territory => ({
+  id,
+  city: 'X',
+  address: id,
+  note: '',
+  congregationId: 'c',
+  icon: TerritoryIcon.WOMAN,
+  geo: geo ? { lat, lng } : undefined,
+  lastVisit: new Date(1000),
+});
+
+describe('TeamDistributionService', () => {
+  let svc: TeamDistributionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    svc = TestBed.inject(TeamDistributionService);
+  });
+
+  it('covers every territory and never exceeds 5 people per car', () => {
+    const sel = Array.from({ length: 12 }, (_, i) => T(`t${i}`, 0, i));
+    const plan = svc.distribute(sel, { men: 12, women: 8, cars: 6, durationMin: 120 });
+    expect(plan.groupPlan.pairs + plan.groupPlan.trios).toBe(10);
+    const all = plan.cars.flatMap(c => c.territories.map(t => t.id)).sort();
+    expect(all).toEqual(sel.map(t => t.id).sort());
+    expect(plan.cars.every(c => c.people <= 5)).toBe(true); // hard cap enforced
+  });
+
+  it('economizes to the fewest cars and leaves spares behind', () => {
+    const sel = Array.from({ length: 12 }, (_, i) => T(`t${i}`, 0, i));
+    const plan = svc.distribute(sel, { men: 12, women: 8, cars: 6, economize: true, durationMin: 120 });
+    expect(plan.carsNeeded).toBe(5); // 10 pairs, 2 per car (4 people <= 5)
+    expect(plan.effectiveCars).toBe(5);
+    expect(plan.carsLeftBehind).toBe(1);
+    expect(plan.cars.every(c => c.people <= 5)).toBe(true);
+  });
+
+  it('spreads across more cars when economize is off (still <= 5 per car)', () => {
+    const sel = Array.from({ length: 8 }, (_, i) => T(`t${i}`, 0, i));
+    const on = svc.distribute(sel, { men: 4, women: 4, cars: 4, economize: true, durationMin: 120 });
+    const off = svc.distribute(sel, { men: 4, women: 4, cars: 4, economize: false, durationMin: 120 });
+    expect(on.effectiveCars).toBe(2); // 4 pairs, 2 per car
+    expect(off.effectiveCars).toBeGreaterThan(on.effectiveCars); // uses more of the 4 cars
+    expect(off.cars.every(c => c.people <= 5)).toBe(true);
+  });
+
+  it('warns when there are not enough cars to seat everyone at 5 per car', () => {
+    const sel = Array.from({ length: 6 }, (_, i) => T(`t${i}`, 0, i));
+    const plan = svc.distribute(sel, { men: 12, women: 8, cars: 3, durationMin: 120 }); // needs 5 cars, has 3
+    expect(plan.carsNeeded).toBeGreaterThan(plan.carsAvailable);
+    expect(plan.seatWarning).toBe(true);
+  });
+
+  it('never drops unlocated territories', () => {
+    const sel = [T('a', 0, 0), T('n1', 0, 0, false), T('n2', 0, 0, false)];
+    const plan = svc.distribute(sel, { men: 4, women: 2, cars: 2, durationMin: 120 });
+    const all = plan.cars.flatMap(c => c.territories.map(t => t.id)).sort();
+    expect(all).toEqual(['a', 'n1', 'n2']);
+  });
+
+  it('returns an empty plan (never crashes/drops) when the crew forms no work groups', () => {
+    const sel = [T('a', 0, 0), T('n1', 0, 0, false)]; // includes an unlocated territory
+    // 1 man + 1 woman form zero same-sex groups; must not throw on the unlocated round-robin.
+    expect(() => svc.distribute(sel, { men: 1, women: 1, cars: 2, durationMin: 120 })).not.toThrow();
+    const plan = svc.distribute(sel, { men: 1, women: 1, cars: 2, durationMin: 120 });
+    expect(plan.cars).toEqual([]);
+    expect(plan.effectiveCars).toBe(0);
+    expect(plan.groupPlan.unplacedMen).toBe(1);
+  });
+
+  it('surfaces unplaced people from the group plan', () => {
+    const sel = Array.from({ length: 4 }, (_, i) => T(`t${i}`, 0, i));
+    const plan = svc.distribute(sel, { men: 1, women: 0, cars: 1, durationMin: 120 });
+    expect(plan.groupPlan.unplacedMen).toBe(1);
+  });
+});

--- a/apps/ministry-maps/src/app/features/territory/services/team-distribution.service.ts
+++ b/apps/ministry-maps/src/app/features/territory/services/team-distribution.service.ts
@@ -1,0 +1,230 @@
+import { Injectable, inject } from '@angular/core';
+import { Territory } from '../../../../models/territory';
+import { splitRouteIntoTeams, haversineKm, GeoPointLike } from '../../../shared/route-optimizer';
+import { RouteOptimizerService } from './route-optimizer.service';
+import { formGroups, GroupPlan, WorkGroup } from './pairing';
+
+const AVG_KMH = 30;
+/** Fallback minutes spent per visited person when the caller doesn't specify. */
+const DEFAULT_VISIT_MIN = 15;
+const DEFAULT_DURATION_MIN = 120;
+/** Minimum seats we assume every car has (owner rule: "cars are >= 5 at minimum"). */
+export const SEATS_PER_CAR = 5;
+
+export interface CarPlan {
+  carIndex: number; // 0-based
+  territories: Territory[]; // this car's stops, in route order (unlocated appended)
+  groups: WorkGroup[]; // the pairs/trios riding in this car
+  pairs: number;
+  trios: number;
+  people: number;
+  men: number;
+  women: number;
+  noManWithWomen: boolean; // car carries women but no man (a safety concern)
+  perGroupTerritories: number; // territories each pair/trio in this car handles (they work in parallel)
+  overCapacity: boolean; // people in this car exceed SEATS_PER_CAR
+  totalKm: number;
+  estMinutes: number;
+}
+
+export interface DistributionPlan {
+  cars: CarPlan[];
+  unlocated: Territory[];
+  totalKm: number;
+  avgLegKm: number;
+  groupPlan: GroupPlan; // overall composition + any unplaced people
+  carsAvailable: number; // cars the crew has
+  carsNeeded: number; // minimum cars to seat everyone at <= SEATS_PER_CAR
+  effectiveCars: number; // cars actually sent out (may be fewer - leaving cars behind)
+  carsLeftBehind: number; // carsAvailable - effectiveCars
+  withinBudget: boolean; // every car sent fits the duration budget
+  seatWarning: boolean; // not enough cars to seat everyone at <= SEATS_PER_CAR
+}
+
+export interface TeamInput {
+  men: number;
+  women: number;
+  cars: number;
+  visitMin?: number; // avg minutes spent per visited person (default 15)
+  durationMin?: number; // session time budget (default 120)
+  economize?: boolean; // true (default) = fewest cars; false = spread across all available cars
+}
+
+@Injectable({ providedIn: 'root' })
+export class TeamDistributionService {
+  private readonly optimizer = inject(RouteOptimizerService);
+
+  /**
+   * Full plan: form work groups (pairs/trios) from men+women, optimize the selected
+   * territories, split the route one segment per work group, then pack the groups into
+   * cars - never more than SEATS_PER_CAR people per car. Territories without coordinates
+   * are spread round-robin across the cars and never dropped.
+   *
+   * `economize` (default true) uses the FEWEST cars (leaving spare cars behind); when
+   * false, the groups are spread across all of the crew's cars.
+   */
+  distribute(selected: Territory[], team: TeamInput): DistributionPlan {
+    const visitMin = team.visitMin && team.visitMin > 0 ? team.visitMin : DEFAULT_VISIT_MIN;
+    const durationMin = team.durationMin && team.durationMin > 0 ? team.durationMin : DEFAULT_DURATION_MIN;
+    const economize = team.economize !== false;
+    const groupPlan = formGroups(team.men, team.women);
+    const numGroups = Math.max(1, groupPlan.groups.length);
+
+    const { ordered, unlocated, totalKm } = this.optimizer.optimize(selected);
+
+    // One balanced route segment per work group (independent of how many cars we send).
+    const { teams } = splitRouteIntoTeams(ordered, { pairs: numGroups, cars: numGroups, visitMin });
+    const segments = teams.map(t => t.items);
+    while (segments.length < numGroups) segments.push([]);
+
+    const carsAvailable = Math.max(1, Math.floor(team.cars) || 1);
+    const groups = groupPlan.groups;
+
+    // Minimum cars to seat everyone at <= SEATS_PER_CAR (pack tight, no car cap).
+    const carsNeeded = this.packGroups(groups, SEATS_PER_CAR, Number.MAX_SAFE_INTEGER).length;
+
+    // Economize: fill each car up to SEATS_PER_CAR -> fewest cars, leaving spares behind.
+    // Otherwise: spread the groups across all of the crew's cars (fewer people per car,
+    // tighter clusters). Both keep every car <= SEATS_PER_CAR whenever there are enough cars.
+    const packed = economize
+      ? this.packGroups(groups, SEATS_PER_CAR, carsAvailable)
+      : this.evenSplit(groups, carsAvailable);
+
+    // No valid work groups (e.g. no crew entered, or a lone man+woman who can't pair):
+    // return an empty plan rather than crashing or silently dropping the selection.
+    if (packed.length === 0) {
+      const legs0 = Math.max(1, ordered.length - 1);
+      return {
+        cars: [],
+        unlocated,
+        totalKm,
+        avgLegKm: Math.round((totalKm / legs0) * 100) / 100,
+        groupPlan,
+        carsAvailable,
+        carsNeeded,
+        effectiveCars: 0,
+        carsLeftBehind: 0,
+        withinBudget: true,
+        seatWarning: false,
+      };
+    }
+
+    const cars = this.buildCars(packed, groups, segments, unlocated, visitMin);
+    const legs = Math.max(1, ordered.length - 1);
+    const avgLegKm = Math.round((totalKm / legs) * 100) / 100;
+    const effectiveCars = cars.length;
+
+    return {
+      cars,
+      unlocated,
+      totalKm,
+      avgLegKm,
+      groupPlan,
+      carsAvailable,
+      carsNeeded,
+      effectiveCars,
+      carsLeftBehind: Math.max(0, carsAvailable - effectiveCars),
+      withinBudget: cars.every(c => c.estMinutes <= durationMin),
+      seatWarning: carsNeeded > carsAvailable,
+    };
+  }
+
+  /**
+   * Greedily packs consecutive work groups into cars, never exceeding SEATS_PER_CAR
+   * people. Returns groups of group-indices (contiguous, so each car stays a tight
+   * geographic cluster). Starts a new car when the current one hits `targetPerCar` or
+   * would overflow - up to `maxCars` (past that, groups overflow the last car).
+   */
+  private packGroups(groups: WorkGroup[], targetPerCar: number, maxCars: number): number[][] {
+    const people = (car: number[]) => car.reduce((s, idx) => s + groups[idx].size, 0);
+    const cars: number[][] = [[]];
+    for (let i = 0; i < groups.length; i++) {
+      const cur = cars[cars.length - 1];
+      const p = people(cur);
+      const wouldOverflow = p + groups[i].size > SEATS_PER_CAR;
+      const reachedTarget = p >= targetPerCar;
+      if (cur.length > 0 && (wouldOverflow || reachedTarget) && cars.length < maxCars) {
+        cars.push([i]);
+      } else if (cur.length > 0 && wouldOverflow) {
+        // Out of cars but this group won't fit - drop it into the least-full car so the
+        // unavoidable overflow is spread evenly instead of piling onto the last car.
+        let best = cur;
+        for (const c of cars) if (people(c) < people(best)) best = c;
+        best.push(i);
+      } else {
+        cur.push(i);
+      }
+    }
+    return cars.filter(c => c.length > 0);
+  }
+
+  /**
+   * Spreads the work groups evenly (by count) across up to `maxCars` cars - one contiguous
+   * chunk per car. Used when NOT economizing, to put fewer people in each car and split the
+   * route into smaller, tighter clusters. Stays <= SEATS_PER_CAR whenever cars are sufficient.
+   */
+  private evenSplit(groups: WorkGroup[], maxCars: number): number[][] {
+    const cars = Math.max(1, Math.min(maxCars, groups.length));
+    const base = Math.floor(groups.length / cars);
+    const extra = groups.length % cars;
+    const res: number[][] = [];
+    let g = 0;
+    for (let c = 0; c < cars; c++) {
+      const cnt = base + (c < extra ? 1 : 0);
+      const idx: number[] = [];
+      for (let k = 0; k < cnt; k++) idx.push(g++);
+      res.push(idx);
+    }
+    return res;
+  }
+
+  private buildCars(
+    packed: number[][],
+    groups: WorkGroup[],
+    segments: Territory[][],
+    unlocated: Territory[],
+    visitMin: number
+  ): CarPlan[] {
+    const cars: CarPlan[] = packed.map((indices, c) => {
+      const carGroups = indices.map(i => groups[i]);
+      const carTerritories = indices.flatMap(i => segments[i]);
+      const men = carGroups.reduce((s, x) => s + x.men, 0);
+      const women = carGroups.reduce((s, x) => s + x.women, 0);
+      return {
+        carIndex: c,
+        territories: carTerritories,
+        groups: carGroups,
+        pairs: carGroups.filter(x => x.kind === 'pair').length,
+        trios: carGroups.filter(x => x.kind === 'trio').length,
+        people: men + women,
+        men,
+        women,
+        noManWithWomen: women > 0 && men === 0,
+        perGroupTerritories: 0,
+        overCapacity: men + women > SEATS_PER_CAR,
+        totalKm: 0,
+        estMinutes: 0,
+      };
+    });
+
+    // Spread unlocated territories round-robin across the cars (never dropped).
+    unlocated.forEach((u, i) => cars[i % cars.length].territories.push(u));
+
+    // Per-car travel + elapsed time. Groups inside a car work in PARALLEL, so elapsed
+    // time is the whole car workload divided by how many groups it carries.
+    for (const car of cars) {
+      let km = 0;
+      const located = car.territories.filter(t => t.geo);
+      for (let i = 1; i < located.length; i++) {
+        km += haversineKm(located[i - 1].geo as GeoPointLike, located[i].geo as GeoPointLike);
+      }
+      car.totalKm = Math.round(km * 10) / 10;
+      const groupsN = Math.max(1, car.groups.length);
+      const totalWorkMin = visitMin * car.territories.length + (car.totalKm / AVG_KMH) * 60;
+      car.estMinutes = Math.round(totalWorkMin / groupsN);
+      car.perGroupTerritories = Math.round(car.territories.length / groupsN);
+    }
+
+    return cars;
+  }
+}

--- a/apps/ministry-maps/src/app/repositories/firebase/firebase-territory-datasource.service.ts
+++ b/apps/ministry-maps/src/app/repositories/firebase/firebase-territory-datasource.service.ts
@@ -8,6 +8,7 @@ import {
   documentId,
   DocumentReference,
   Firestore,
+  GeoPoint,
   getDoc,
   getDocs,
   limit,
@@ -15,6 +16,7 @@ import {
   query,
   runTransaction,
   setDoc,
+  Timestamp,
   updateDoc,
   where
 } from '@angular/fire/firestore';
@@ -35,6 +37,9 @@ export const convertTerritoryFirebaseTimestampsToDate = (data: FirebaseTerritory
   return {
     ...data,
     lastVisit: data.lastVisit?.toDate(),
+    geo: data.geo ? { lat: data.geo.latitude, lng: data.geo.longitude } : undefined,
+    geoStatus: data.geoStatus ?? undefined,
+    geocodedAt: data.geocodedAt ? data.geocodedAt.toDate() : undefined,
     recentHistory: data.recentHistory?.map(h => ({
       ...h,
       date: h?.date?.toDate(),
@@ -164,10 +169,12 @@ export class FirebaseTerritoryDatasourceService implements TerritoryRepository, 
     };
 
     const newTerritoryDocRef = doc(this.territoriesCollection);
+    const territoryToPersist = { ...territoryWithoutHistory, id: newTerritoryDocRef.id };
+    this.convertTerritoryGeoFieldsToFirestore(territoryToPersist);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     // Creating a reference to the new document, so we can get the id
-    const newTerritory$ = from(setDoc(newTerritoryDocRef, { ...territoryWithoutHistory, id: newTerritoryDocRef.id }));
+    const newTerritory$ = from(setDoc(newTerritoryDocRef, territoryToPersist));
 
     return newTerritory$.pipe(
       switchMap(() =>
@@ -190,6 +197,7 @@ export class FirebaseTerritoryDatasourceService implements TerritoryRepository, 
     const territoryCopy = structuredClone(territoryWithoutHistory);
     // FIXME: I don't know why the converter is not getting this on the 'toFirestore'
     removeUndefined(territoryCopy);
+    this.convertTerritoryGeoFieldsToFirestore(territoryCopy);
 
     return from(updateDoc(territoryDocRef, territoryCopy));
   }
@@ -206,6 +214,7 @@ export class FirebaseTerritoryDatasourceService implements TerritoryRepository, 
         // FIXME: I don't know why the converter is not getting this on the 'toFirestore'
         const territoryCopy = structuredClone(territory);
         removeUndefined(territoryCopy);
+        this.convertTerritoryGeoFieldsToFirestore(territoryCopy);
 
         return transaction.update(territoryDocRef, territoryCopy);
       });
@@ -292,6 +301,22 @@ export class FirebaseTerritoryDatasourceService implements TerritoryRepository, 
     );
 
     return forkJoin([deleteRecentHistory$, deleteHistory$]).pipe(map((_) => undefined));
+  }
+
+  /**
+   * Converts the domain geo/date fields to their Firestore representations (GeoPoint/Timestamp) in-place
+   * before persisting, mirroring how the Date `lastVisit` field is stored.
+   */
+  private convertTerritoryGeoFieldsToFirestore(payload: {
+    geo?: { lat: number; lng: number } | GeoPoint;
+    geocodedAt?: Date | Timestamp;
+  }): void {
+    if (payload.geo && !(payload.geo instanceof GeoPoint)) {
+      payload.geo = new GeoPoint(payload.geo.lat, payload.geo.lng);
+    }
+    if (payload.geocodedAt instanceof Date) {
+      payload.geocodedAt = Timestamp.fromDate(payload.geocodedAt);
+    }
   }
 
   /** Gets the {@link CollectionReference} of the Territory History sub-collection */

--- a/apps/ministry-maps/src/app/shared/geocoding/geocode-parse.spec.ts
+++ b/apps/ministry-maps/src/app/shared/geocoding/geocode-parse.spec.ts
@@ -1,0 +1,20 @@
+import { coordsFromResolvedUrl, cleanAddressFromUrl, cepFromText, isInRegion } from './geocode-parse';
+
+describe('geocode-parse', () => {
+  it('extracts @lat,lng and !3d!4d coords', () => {
+    expect(coordsFromResolvedUrl('https://www.google.com/maps/@-22.71364,-47.36594,17z')).toEqual({ lat: -22.71364, lng: -47.36594 });
+    expect(coordsFromResolvedUrl('x!3d-22.78799!4d-47.28769z')).toEqual({ lat: -22.78799, lng: -47.28769 });
+    expect(coordsFromResolvedUrl('https://maps.app.goo.gl/abc')).toBeNull();
+  });
+  it('double-decodes the /place/ address', () => {
+    const u = 'https://www.google.com/maps/place/R.%2BJ%25C3%25BAlio%2BMarmile,%2B728%2B-%2BJardim%2B%25C3%2589den,%2BNova%2BOdessa%2B-%2BSP,%2B13460-000/data%3D!4m2';
+    expect(cleanAddressFromUrl(u)).toContain('Júlio Marmile, 728');
+    expect(cleanAddressFromUrl(u)).toContain('13460-000');
+  });
+  it('finds CEP and rejects the viewport-center constant', () => {
+    expect(cepFromText('Nova Odessa - SP, 13460-000')).toBe('13460-000');
+    expect(isInRegion({ lat: -22.742162, lng: -47.284224 })).toBe(false); // constant
+    expect(isInRegion({ lat: -22.71364, lng: -47.36594 })).toBe(true);
+    expect(isInRegion({ lat: -23.5, lng: -46.6 })).toBe(false); // São Paulo city, out of bbox
+  });
+});

--- a/apps/ministry-maps/src/app/shared/geocoding/geocode-parse.ts
+++ b/apps/ministry-maps/src/app/shared/geocoding/geocode-parse.ts
@@ -1,0 +1,42 @@
+export interface LatLng { lat: number; lng: number; }
+
+// Google's constant viewport-center that leaks into non-place pages - never a real pin.
+const VIEWPORT_CENTER: LatLng = { lat: -22.742162, lng: -47.284224 };
+// Bounding box around Americana / Santa Bárbara d'Oeste / Nova Odessa (tri-city cluster ~lat -22.7).
+// latMin is held at -23 so points as far south as São Paulo city (lat ~-23.55) fall outside the region.
+const BBOX = { latMin: -23, latMax: -21, lngMin: -48, lngMax: -46 };
+
+export function isInRegion(c: LatLng | null): c is LatLng {
+  if (!c) return false;
+  const near =
+    Math.abs(c.lat - VIEWPORT_CENTER.lat) < 1e-3 &&
+    Math.abs(c.lng - VIEWPORT_CENTER.lng) < 1e-3;
+  return !near &&
+    c.lat > BBOX.latMin && c.lat < BBOX.latMax &&
+    c.lng > BBOX.lngMin && c.lng < BBOX.lngMax;
+}
+
+/** Extract lat/lng from a resolved Google Maps URL (@lat,lng or !3d..!4d..). */
+export function coordsFromResolvedUrl(url: string): LatLng | null {
+  const at = url.match(/@(-?\d{1,2}\.\d{4,}),(-?\d{1,3}\.\d{4,})/);
+  if (at) return { lat: +at[1], lng: +at[2] };
+  const bang = url.match(/!3d(-?\d{1,2}\.\d{4,})!4d(-?\d{1,3}\.\d{4,})/);
+  if (bang) return { lat: +bang[1], lng: +bang[2] };
+  return null;
+}
+
+/** Pull the clean /maps/place/<address>/ segment (double-decoded) from a resolved URL. */
+export function cleanAddressFromUrl(url: string): string | null {
+  const m = url.match(/\/place\/([^/@]+)/);
+  if (!m) return null;
+  let s = m[1];
+  for (let i = 0; i < 2; i++) { try { s = decodeURIComponent(s); } catch { break; } }
+  return s.replace(/\+/g, ' ').trim() || null;
+}
+
+/** Brazilian postal code (CEP) e.g. 13460-000. */
+export function cepFromText(s: string | undefined | null): string | null {
+  if (!s) return null;
+  const m = s.match(/\b\d{5}-?\d{3}\b/);
+  return m ? m[0] : null;
+}

--- a/apps/ministry-maps/src/app/shared/route-optimizer/exact-tsp.ts
+++ b/apps/ministry-maps/src/app/shared/route-optimizer/exact-tsp.ts
@@ -1,0 +1,139 @@
+import type { TourEndpoint, TourMatrix, SolveTourResult } from './solve-tour';
+
+/**
+ * Exact TSP/path solver via Held-Karp dynamic programming.
+ *
+ * - Start node is always index 0.
+ * - 'round_trip' returns to index 0 at the end.
+ * - 'open' ends at whichever node minimises total duration.
+ * - The objective is total duration; distance is reported for the winning order.
+ *
+ * Feasible for N <= 15: O(N^2 * 2^N), which stays inside the route-matrix cap
+ * without the bad local-search traps that hurt dense walking stop lists.
+ */
+export function solveExactTour(input: {
+  durationMatrix: TourMatrix;
+  distanceMatrix: TourMatrix;
+  endpoint: TourEndpoint;
+}): SolveTourResult {
+  const { durationMatrix, distanceMatrix, endpoint } = input;
+  const n = durationMatrix.length;
+
+  if (n === 0) {
+    return { order: [], totalDuration: 0, totalDistance: 0 };
+  }
+  if (n === 1) {
+    return { order: [0], totalDuration: 0, totalDistance: 0 };
+  }
+
+  const stateCount = 1 << n;
+  const startMask = 1;
+  const fullMask = stateCount - 1;
+  const infinity = Number.POSITIVE_INFINITY;
+  const dp = Array.from({ length: stateCount }, () => {
+    const row = new Float64Array(n);
+    row.fill(infinity);
+    return row;
+  });
+  const parent = Array.from({ length: stateCount }, () => {
+    const row = new Int16Array(n);
+    row.fill(-1);
+    return row;
+  });
+
+  dp[startMask][0] = 0;
+
+  for (let mask = startMask; mask < stateCount; mask += 1) {
+    if ((mask & startMask) === 0) {
+      continue;
+    }
+
+    for (let last = 0; last < n; last += 1) {
+      if ((mask & (1 << last)) === 0) {
+        continue;
+      }
+
+      const currentCost = dp[mask][last];
+      if (!Number.isFinite(currentCost)) {
+        continue;
+      }
+
+      for (let next = 1; next < n; next += 1) {
+        const nextBit = 1 << next;
+        if ((mask & nextBit) !== 0) {
+          continue;
+        }
+
+        const nextMask = mask | nextBit;
+        const nextCost = currentCost + durationMatrix[last][next];
+        if (nextCost < dp[nextMask][next]) {
+          dp[nextMask][next] = nextCost;
+          parent[nextMask][next] = last;
+        }
+      }
+    }
+  }
+
+  let bestDuration = infinity;
+  let bestLast = 0;
+  for (let last = 0; last < n; last += 1) {
+    let total = dp[fullMask][last];
+    if (endpoint === 'round_trip') {
+      total += durationMatrix[last][0];
+    }
+
+    if (total < bestDuration) {
+      bestDuration = total;
+      bestLast = last;
+    }
+  }
+
+  const order = reconstructOrder(parent, fullMask, bestLast);
+
+  return {
+    order,
+    totalDuration: Number.isFinite(bestDuration) ? bestDuration : 0,
+    totalDistance: tourCost(order, distanceMatrix, endpoint),
+  };
+}
+
+function reconstructOrder(
+  parent: Int16Array[],
+  initialMask: number,
+  initialLast: number,
+): number[] {
+  const order: number[] = [];
+  let mask = initialMask;
+  let last = initialLast;
+
+  while (last >= 0) {
+    order.push(last);
+    const previous = parent[mask][last];
+    mask ^= 1 << last;
+    last = previous;
+  }
+
+  order.reverse();
+  return order;
+}
+
+function tourCost(
+  order: number[],
+  matrix: TourMatrix,
+  endpoint: TourEndpoint,
+): number {
+  if (order.length < 2) {
+    return 0;
+  }
+
+  let cost = 0;
+  for (let i = 0; i < order.length - 1; i += 1) {
+    cost += matrix[order[i]][order[i + 1]];
+  }
+
+  if (endpoint === 'round_trip') {
+    cost += matrix[order[order.length - 1]][order[0]];
+  }
+
+  return cost;
+}

--- a/apps/ministry-maps/src/app/shared/route-optimizer/haversine.ts
+++ b/apps/ministry-maps/src/app/shared/route-optimizer/haversine.ts
@@ -1,0 +1,24 @@
+export interface GeoPointLike {
+  lat: number;
+  lng: number;
+}
+
+const EARTH_RADIUS_KM = 6371;
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+
+/** Great-circle distance in kilometres between two lat/lng points. */
+export function haversineKm(a: GeoPointLike, b: GeoPointLike): number {
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/** Full symmetric N×N straight-line distance matrix (km). */
+export function buildHaversineMatrix(points: GeoPointLike[]): number[][] {
+  return points.map(from => points.map(to => haversineKm(from, to)));
+}

--- a/apps/ministry-maps/src/app/shared/route-optimizer/index.ts
+++ b/apps/ministry-maps/src/app/shared/route-optimizer/index.ts
@@ -1,0 +1,8 @@
+export { solveExactTour } from './exact-tsp';
+export { solveNearestNeighborTwoOpt } from './nn-2opt';
+export { solveTour, StepCapExceededError, EXACT_TSP_MAX_N, HEURISTIC_MAX_N } from './solve-tour';
+export type { TourEndpoint, TourMatrix, SolveTourInput, SolveTourResult } from './solve-tour';
+export { haversineKm, buildHaversineMatrix } from './haversine';
+export type { GeoPointLike } from './haversine';
+export { splitRouteIntoTeams } from './split-route';
+export type { TeamRoute, SplitOptions, SplitResult } from './split-route';

--- a/apps/ministry-maps/src/app/shared/route-optimizer/nn-2opt.ts
+++ b/apps/ministry-maps/src/app/shared/route-optimizer/nn-2opt.ts
@@ -1,0 +1,130 @@
+import type { TourEndpoint, TourMatrix, SolveTourResult } from './solve-tour';
+
+/**
+ * Nearest-neighbor seed followed by 2-opt local search.
+ *
+ * - Start node is fixed at index 0.
+ * - 'round_trip' returns to index 0; 'open' terminates wherever yields
+ *   the lowest total duration.
+ * - The 2-opt loop is capped at N^2 iterations to bound runtime.
+ *
+ * Intended for 10 < N <= 15 where exact TSP is too slow.
+ */
+export function solveNearestNeighborTwoOpt(input: {
+  durationMatrix: TourMatrix;
+  distanceMatrix: TourMatrix;
+  endpoint: TourEndpoint;
+}): SolveTourResult {
+  const { durationMatrix, distanceMatrix, endpoint } = input;
+  const n = durationMatrix.length;
+
+  if (n === 0) {
+    return { order: [], totalDuration: 0, totalDistance: 0 };
+  }
+  if (n === 1) {
+    return { order: [0], totalDuration: 0, totalDistance: 0 };
+  }
+
+  const seed = nearestNeighborSeed(durationMatrix);
+  const optimized = twoOpt(seed, durationMatrix, endpoint);
+
+  const totalDuration = tourCost(optimized, durationMatrix, endpoint);
+  const totalDistance = tourCost(optimized, distanceMatrix, endpoint);
+
+  return {
+    order: optimized,
+    totalDuration,
+    totalDistance,
+  };
+}
+
+function nearestNeighborSeed(matrix: TourMatrix): number[] {
+  const n = matrix.length;
+  const order = [0];
+  const visited = new Array<boolean>(n).fill(false);
+  visited[0] = true;
+
+  for (let step = 1; step < n; step += 1) {
+    const current = order[order.length - 1];
+    let bestIndex = -1;
+    let bestCost = Number.POSITIVE_INFINITY;
+    for (let j = 0; j < n; j += 1) {
+      if (visited[j]) continue;
+      const cost = matrix[current][j];
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestIndex = j;
+      }
+    }
+    if (bestIndex < 0) break;
+    visited[bestIndex] = true;
+    order.push(bestIndex);
+  }
+
+  return order;
+}
+
+function twoOpt(
+  initial: number[],
+  matrix: TourMatrix,
+  endpoint: TourEndpoint,
+): number[] {
+  const n = initial.length;
+  if (n < 4) return initial.slice();
+
+  let best = initial.slice();
+  let bestCost = tourCost(best, matrix, endpoint);
+  const iterationCap = n * n;
+  let iterations = 0;
+  let improved = true;
+
+  while (improved && iterations < iterationCap) {
+    improved = false;
+
+    // Indices 1..n-1 are reorderable; start (index 0) is pinned.
+    // For round_trip, the closing edge is best[n-1] -> best[0]; reversing
+    // segment [i..k] for any 1 <= i < k <= n-1 keeps the start pinned.
+    // For open, the same range applies; the trailing edge is just dropped
+    // from the cost.
+    for (let i = 1; i < n - 1; i += 1) {
+      for (let k = i + 1; k < n; k += 1) {
+        iterations += 1;
+        if (iterations > iterationCap) break;
+
+        const candidate = twoOptSwap(best, i, k);
+        const candidateCost = tourCost(candidate, matrix, endpoint);
+        if (candidateCost + 1e-9 < bestCost) {
+          best = candidate;
+          bestCost = candidateCost;
+          improved = true;
+        }
+      }
+      if (iterations > iterationCap) break;
+    }
+  }
+
+  return best;
+}
+
+function twoOptSwap(order: number[], i: number, k: number): number[] {
+  const next = order.slice(0, i);
+  for (let j = k; j >= i; j -= 1) next.push(order[j]);
+  for (let j = k + 1; j < order.length; j += 1) next.push(order[j]);
+  return next;
+}
+
+function tourCost(
+  order: number[],
+  matrix: TourMatrix,
+  endpoint: TourEndpoint,
+): number {
+  if (order.length < 2) return 0;
+  let cost = 0;
+  for (let i = 0; i < order.length - 1; i += 1) {
+    cost += matrix[order[i]][order[i + 1]];
+  }
+  if (endpoint === 'round_trip') {
+    cost += matrix[order[order.length - 1]][order[0]];
+  }
+  return cost;
+}

--- a/apps/ministry-maps/src/app/shared/route-optimizer/route-optimizer.spec.ts
+++ b/apps/ministry-maps/src/app/shared/route-optimizer/route-optimizer.spec.ts
@@ -1,0 +1,35 @@
+import { buildHaversineMatrix, haversineKm } from './haversine';
+import { solveTour, StepCapExceededError } from './solve-tour';
+
+describe('haversine', () => {
+  it('is ~0 for identical points and symmetric', () => {
+    const a = { lat: -22.74, lng: -47.33 };
+    expect(haversineKm(a, a)).toBeCloseTo(0, 5);
+    const b = { lat: -22.7, lng: -47.29 };
+    expect(haversineKm(a, b)).toBeCloseTo(haversineKm(b, a), 6);
+  });
+});
+
+describe('solveTour (open path from index 0)', () => {
+  it('orders a unit square as the obvious perimeter path', () => {
+    // 0=(0,0) 1=(0,1) 2=(1,1) 3=(1,0) - colinear-free square
+    const pts = [
+      { lat: 0, lng: 0 },
+      { lat: 0, lng: 1 },
+      { lat: 1, lng: 1 },
+      { lat: 1, lng: 0 },
+    ];
+    const m = buildHaversineMatrix(pts);
+    const { order } = solveTour({ durationMatrix: m, distanceMatrix: m, endpoint: 'open' });
+    expect(order[0]).toBe(0); // start pinned at index 0
+    // neighbours 1 and 3 are adjacent to 0; 2 is the far corner and must be visited between them
+    expect(order[2]).toBe(2);
+    expect(new Set(order)).toEqual(new Set([0, 1, 2, 3]));
+  });
+
+  it('throws StepCapExceededError above 15 stops', () => {
+    const n = 16;
+    const m = Array.from({ length: n }, () => new Array(n).fill(1));
+    expect(() => solveTour({ durationMatrix: m, distanceMatrix: m, endpoint: 'open' })).toThrow(StepCapExceededError);
+  });
+});

--- a/apps/ministry-maps/src/app/shared/route-optimizer/solve-tour.ts
+++ b/apps/ministry-maps/src/app/shared/route-optimizer/solve-tour.ts
@@ -1,0 +1,49 @@
+import { solveExactTour } from './exact-tsp';
+
+export type TourEndpoint = 'round_trip' | 'open';
+
+export type TourMatrix = number[][];
+
+export interface SolveTourInput {
+  durationMatrix: TourMatrix;
+  distanceMatrix: TourMatrix;
+  endpoint: TourEndpoint;
+}
+
+export interface SolveTourResult {
+  order: number[];
+  totalDuration: number;
+  totalDistance: number;
+}
+
+export const EXACT_TSP_MAX_N = 15;
+export const HEURISTIC_MAX_N = 15;
+
+export class StepCapExceededError extends Error {
+  constructor(readonly n: number, readonly cap = HEURISTIC_MAX_N) {
+    super(`Step cap exceeded: ${n} > ${cap}`);
+    this.name = 'StepCapExceededError';
+  }
+}
+
+/**
+ * Dispatch entry point: use exact dynamic-programming TSP within the API cap. Throws
+ * {@link StepCapExceededError} for N > HEURISTIC_MAX_N so the caller can
+ * map it to `step_cap_exceeded` without ever touching the matrix API.
+ */
+export function solveTour(input: SolveTourInput): SolveTourResult {
+  const { durationMatrix, distanceMatrix, endpoint } = input;
+  const n = durationMatrix.length;
+
+  if (distanceMatrix.length !== n) {
+    throw new Error(
+      `solveTour: duration/distance matrix size mismatch (${n} vs ${distanceMatrix.length})`,
+    );
+  }
+
+  if (n > HEURISTIC_MAX_N) {
+    throw new StepCapExceededError(n);
+  }
+
+  return solveExactTour({ durationMatrix, distanceMatrix, endpoint });
+}

--- a/apps/ministry-maps/src/app/shared/route-optimizer/split-route.property.spec.ts
+++ b/apps/ministry-maps/src/app/shared/route-optimizer/split-route.property.spec.ts
@@ -1,0 +1,68 @@
+import { splitRouteIntoTeams } from './split-route';
+
+// Deterministic PRNG so a failure is reproducible.
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Item = { id: string; geo: { lat: number; lng: number } };
+
+describe('splitRouteIntoTeams fuzz invariants', () => {
+  it('holds all invariants over 5000 random cases', () => {
+    const rnd = mulberry32(12345);
+    for (let iter = 0; iter < 5000; iter++) {
+      const n = Math.floor(rnd() * 41); // 0..40
+      const pairs = 1 + Math.floor(rnd() * 8); // 1..8
+      const cars = Math.floor(rnd() * 9); // 0..8
+      const ordered: Item[] = Array.from({ length: n }, (_, i) => ({
+        id: `t${i}`,
+        geo: { lat: -22.7 + (rnd() - 0.5) * 0.3, lng: -47.3 + (rnd() - 0.5) * 0.3 },
+      }));
+
+      const r = splitRouteIntoTeams(ordered, { pairs, cars });
+      const ctx = `iter=${iter} n=${n} pairs=${pairs} cars=${cars}`;
+
+      // effectivePairs
+      const expectedK = n === 0 ? 0 : Math.min(pairs, n);
+      expect(r.effectivePairs).toBe(expectedK);
+      expect(r.teams).toHaveLength(expectedK);
+
+      // coverage: every item exactly once, in order
+      const flat = r.teams.flatMap(t => t.items);
+      expect(flat).toEqual(ordered);
+
+      // no empty teams when there is work
+      if (n > 0) expect(r.teams.every(t => t.items.length >= 1)).toBe(true);
+
+      // numeric sanity
+      for (const t of r.teams) {
+        expect(Number.isFinite(t.totalKm)).toBe(true);
+        expect(t.totalKm).toBeGreaterThanOrEqual(0);
+        expect(Number.isFinite(t.estMinutes)).toBe(true);
+        expect(t.estMinutes).toBeGreaterThanOrEqual(0);
+      }
+
+      // car-aware: exactly max(0, K - cars) car-less teams, ranked lowest by
+      // (lone-stop, then internal km) - no car-having team may rank strictly before a car-less one.
+      const carless = r.teams.filter(t => !t.hasCar);
+      expect(carless.length).toBe(Math.max(0, expectedK - cars));
+      if (carless.length && carless.length < expectedK) {
+        const lone = (t: { items: unknown[] }) => (t.items.length >= 2 ? 0 : 1);
+        const carHaving = r.teams.filter(t => t.hasCar);
+        for (const cl of carless) {
+          for (const ch of carHaving) {
+            const chStrictlyBefore =
+              lone(ch) < lone(cl) || (lone(ch) === lone(cl) && ch.totalKm < cl.totalKm - 1e-9);
+            expect(chStrictlyBefore).toBe(false); // ctx: ${ctx}
+          }
+        }
+      }
+    }
+  });
+});

--- a/apps/ministry-maps/src/app/shared/route-optimizer/split-route.spec.ts
+++ b/apps/ministry-maps/src/app/shared/route-optimizer/split-route.spec.ts
@@ -1,0 +1,69 @@
+import { splitRouteIntoTeams } from './split-route';
+
+type Item = { id: string; geo: { lat: number; lng: number } };
+const P = (id: string, lng: number, lat = 0): Item => ({ id, geo: { lat, lng } });
+
+describe('splitRouteIntoTeams', () => {
+  it('returns nothing for empty input', () => {
+    const r = splitRouteIntoTeams<Item>([], { pairs: 3, cars: 3 });
+    expect(r.teams).toEqual([]);
+    expect(r.effectivePairs).toBe(0);
+  });
+
+  it('splits 6 uniform stops into 3 contiguous teams of 2, all with cars', () => {
+    const ordered = [0, 1, 2, 3, 4, 5].map(i => P(`t${i}`, i));
+    const r = splitRouteIntoTeams(ordered, { pairs: 3, cars: 3 });
+    expect(r.effectivePairs).toBe(3);
+    expect(r.teams.map(t => t.items.length)).toEqual([2, 2, 2]);
+    expect(r.teams.map(t => t.items.map(i => i.id))).toEqual([
+      ['t0', 't1'],
+      ['t2', 't3'],
+      ['t4', 't5'],
+    ]);
+    expect(r.teams.every(t => t.hasCar)).toBe(true);
+    r.teams.forEach(t => {
+      expect(t.totalKm).toBeGreaterThan(0);
+      expect(t.estMinutes).toBeGreaterThan(0);
+    });
+  });
+
+  it('assigns every stop exactly once, in order (invariant)', () => {
+    const ordered = [0, 1, 2, 3, 4, 5, 6].map(i => P(`t${i}`, i * 0.5, -22.7));
+    const r = splitRouteIntoTeams(ordered, { pairs: 3, cars: 3 });
+    const flat = r.teams.flatMap(t => t.items);
+    expect(flat).toEqual(ordered);
+  });
+
+  it('never makes more teams than stops', () => {
+    const ordered = [0, 1, 2].map(i => P(`t${i}`, i));
+    const r = splitRouteIntoTeams(ordered, { pairs: 5, cars: 5 });
+    expect(r.requestedPairs).toBe(5);
+    expect(r.effectivePairs).toBe(3);
+    expect(r.teams).toHaveLength(3);
+    expect(r.teams.every(t => t.items.length === 1)).toBe(true);
+  });
+
+  it('gives the shortest sub-route to the single car-less team when cars < pairs', () => {
+    // Last pair of stops is much closer together -> that segment has the smallest km.
+    const ordered = [P('a', 0), P('b', 1), P('c', 2), P('d', 3), P('e', 4), P('f', 4.02)];
+    const r = splitRouteIntoTeams(ordered, { pairs: 3, cars: 2 });
+    const carless = r.teams.filter(t => !t.hasCar);
+    expect(carless).toHaveLength(1);
+    const minKm = Math.min(...r.teams.map(t => t.totalKm));
+    expect(carless[0].totalKm).toBe(minKm);
+  });
+
+  it('balances by internal travel, not the phantom inter-team leg', () => {
+    // A --~10km-- B -~0.5km- C. Into 2 teams, the balanced split by reported (internal)
+    // time is {A} | {B,C} (10 | 21 min), NOT {A,B} | {C} (40 | 10 min).
+    const A = P('A', 0), B = P('B', 0.08983), C = P('C', 0.094322);
+    const r = splitRouteIntoTeams([A, B, C], { pairs: 2, cars: 2 });
+    expect(r.teams.map(t => t.items.map(i => i.id))).toEqual([['A'], ['B', 'C']]);
+  });
+
+  it('gives everyone a car when cars >= pairs', () => {
+    const ordered = [0, 1, 2, 3].map(i => P(`t${i}`, i));
+    const r = splitRouteIntoTeams(ordered, { pairs: 2, cars: 4 });
+    expect(r.teams.every(t => t.hasCar)).toBe(true);
+  });
+});

--- a/apps/ministry-maps/src/app/shared/route-optimizer/split-route.ts
+++ b/apps/ministry-maps/src/app/shared/route-optimizer/split-route.ts
@@ -1,0 +1,123 @@
+import { GeoPointLike, haversineKm } from './haversine';
+
+export interface TeamRoute<T> {
+  /** 0-based team number, in route order. */
+  pairIndex: number;
+  /** false for the car-less teams (assigned the shortest sub-routes). */
+  hasCar: boolean;
+  /** this team's territories, in route order (a contiguous slice of `ordered`). */
+  items: T[];
+  /** intra-team straight-line travel in km (sum of consecutive legs), rounded to 0.1. */
+  totalKm: number;
+  /** visitMin*count + travel minutes, rounded. */
+  estMinutes: number;
+}
+
+export interface SplitOptions {
+  pairs: number;
+  cars: number;
+  visitMin?: number;
+  avgKmh?: number;
+}
+
+export interface SplitResult<T> {
+  teams: TeamRoute<T>[];
+  requestedPairs: number;
+  effectivePairs: number;
+}
+
+/**
+ * Splits an already-optimized route into K balanced, car-aware team sub-routes.
+ *
+ * The split is a contiguous linear partition minimizing the sum of squared per-team
+ * workloads (variance-minimizing), so teams get balanced, geographically tight slices
+ * of the proximity-ordered route. When cars < teams, the (teams - cars) shortest
+ * sub-routes are handed to the car-less teams.
+ *
+ * `ordered` must be territories already in optimized order, each with a `geo` point.
+ */
+export function splitRouteIntoTeams<T extends { geo?: GeoPointLike }>(
+  ordered: T[],
+  options: SplitOptions
+): SplitResult<T> {
+  const visitMin = options.visitMin ?? 10;
+  const avgKmh = options.avgKmh ?? 30;
+  const n = ordered.length;
+
+  if (n === 0) {
+    return { teams: [], requestedPairs: options.pairs, effectivePairs: 0 };
+  }
+
+  const K = Math.min(Math.max(1, Math.floor(options.pairs) || 1), n);
+
+  // leg[i] = km from ordered[i-1] to ordered[i]; leg[0] = 0
+  const leg = new Array<number>(n).fill(0);
+  for (let i = 1; i < n; i++) {
+    leg[i] = haversineKm(ordered[i - 1].geo as GeoPointLike, ordered[i].geo as GeoPointLike);
+  }
+  // Prefix of legs so a segment's INTERNAL travel can be summed in O(1).
+  // L[i] = leg[0] + ... + leg[i-1].
+  const L = new Array<number>(n + 1).fill(0);
+  for (let i = 1; i <= n; i++) L[i] = L[i - 1] + leg[i - 1];
+
+  // Segment [a, b) workload in minutes: visit time + INTERNAL travel only. The leg that
+  // begins a segment is the inter-team hop no team drives, so it is excluded here exactly
+  // as it is from the reported totalKm/estMinutes - the DP optimizes the balance it reports.
+  const segCost = (a: number, b: number) => visitMin * (b - a) + ((L[b] - L[a + 1]) / avgKmh) * 60;
+
+  // dp[k][i] = min achievable sum of squared segment workloads splitting first i
+  // items into k contiguous segments. Squaring penalizes uneven segments, so teams
+  // come out balanced rather than leaving one pair with a single stop.
+  const INF = Number.POSITIVE_INFINITY;
+  const dp: number[][] = Array.from({ length: K + 1 }, () => new Array<number>(n + 1).fill(INF));
+  const cut: number[][] = Array.from({ length: K + 1 }, () => new Array<number>(n + 1).fill(0));
+  dp[0][0] = 0;
+  for (let k = 1; k <= K; k++) {
+    for (let i = k; i <= n; i++) {
+      for (let j = k - 1; j < i; j++) {
+        const seg = segCost(j, i);
+        const cost = dp[k - 1][j] + seg * seg;
+        if (cost < dp[k][i]) {
+          dp[k][i] = cost;
+          cut[k][i] = j;
+        }
+      }
+    }
+  }
+
+  // Reconstruct the K contiguous segment boundaries.
+  const bounds: number[] = [];
+  let end = n;
+  for (let k = K; k >= 1; k--) {
+    bounds.unshift(end);
+    end = cut[k][end];
+  }
+
+  const teams: TeamRoute<T>[] = [];
+  let start = 0;
+  for (let k = 0; k < K; k++) {
+    const segEnd = bounds[k];
+    const items = ordered.slice(start, segEnd);
+    let km = 0;
+    for (let p = start + 1; p < segEnd; p++) km += leg[p]; // legs strictly inside the segment
+    const totalKm = Math.round(km * 10) / 10;
+    const estMinutes = Math.round(visitMin * items.length + (totalKm / avgKmh) * 60);
+    teams.push({ pairIndex: k, hasCar: true, items, totalKm, estMinutes });
+    start = segEnd;
+  }
+
+  // Car-aware: car-less teams should get the tightest WALKABLE clusters. Prefer multi-stop
+  // segments (a lone stop reports 0 internal km but often hides a long approach drive, so it
+  // is the worst pick for a car-less team) then smallest internal distance.
+  const carless = Math.max(0, K - Math.max(0, Math.floor(options.cars) || 0));
+  if (carless > 0) {
+    const ranked = teams
+      .map((t, idx) => ({ idx, lone: t.items.length >= 2 ? 0 : 1, km: t.totalKm }))
+      .sort((a, b) => a.lone - b.lone || a.km - b.km);
+    for (let c = 0; c < carless && c < ranked.length; c++) {
+      teams[ranked[c].idx].hasCar = false;
+    }
+  }
+
+  return { teams, requestedPairs: options.pairs, effectivePairs: K };
+}

--- a/apps/ministry-maps/src/models/firebase/firebase-territory-model.ts
+++ b/apps/ministry-maps/src/models/firebase/firebase-territory-model.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from '@angular/fire/firestore';
+import { GeoPoint, Timestamp } from '@angular/fire/firestore';
 import { TerritoryVisitHistory } from '../territory-visit-history';
 import { Territory } from '../territory';
 
@@ -6,7 +6,9 @@ export type FirebaseTerritoryVisitHistoryModel = Omit<TerritoryVisitHistory, 'da
   date: Timestamp;
 };
 
-export type FirebaseTerritoryModel = Omit<Territory, 'recentHistory'> & {
+export type FirebaseTerritoryModel = Omit<Territory, 'recentHistory' | 'geo' | 'geocodedAt'> & {
   lastVisit: Timestamp | null;
   recentHistory: FirebaseTerritoryVisitHistoryModel[];
+  geo?: GeoPoint | null;
+  geocodedAt?: Timestamp | null;
 };

--- a/apps/ministry-maps/src/models/territory.ts
+++ b/apps/ministry-maps/src/models/territory.ts
@@ -25,4 +25,8 @@ export type Territory = {
   recentHistory?: TerritoryVisitHistory[];
   /** Represents the quantity of people that lives in that Territory. For the majority of cases it will be 1 or null. */
   peopleQuantity?: number;
+  /** Cached geocoded coordinate for this territory, used for route optimization. */
+  geo?: { lat: number; lng: number };
+  geoStatus?: 'ok' | 'approx' | 'failed';
+  geocodedAt?: Date;
 };

--- a/tools/geocode-territories/README.md
+++ b/tools/geocode-territories/README.md
@@ -1,0 +1,62 @@
+# Territory geocoder backfill
+
+One-time local dev tool that attaches a cached `geo` coordinate to every territory
+in the **local Firestore emulator**. It runs a free-first waterfall and only falls
+back to the paid Google Geocoding API for the misses.
+
+## Waterfall
+
+For each territory, in order, stopping at the first in-region hit:
+
+1. **Resolve `mapsLink`** (follow redirects) and read coords straight off the
+   resolved Google Maps URL (`@lat,lng` or `!3d..!4d..`) → `geoStatus: ok`.
+2. **Nominatim (OpenStreetMap)** on the CEP parsed from the resolved/stored address → `geoStatus: approx`.
+3. **Nominatim** on the clean `/place/...` address from the resolved URL → `geoStatus: approx`.
+4. **Nominatim** on the stored `address + city + SP` → `geoStatus: approx`.
+5. **Google Geocoding** on the clean/stored address — **only when `GOOGLE_MAPS_API_KEY`
+   is set** → `geoStatus: ok`.
+6. Otherwise → `geoStatus: failed` (no `geo` written; retried on the next `--only-missing` run).
+
+Every candidate is passed through a region guard that rejects Google's constant
+viewport-center pin (`-22.742162,-47.284224`) and clamps to the tri-city bounding
+box (`lat -24..-21 / lng -48..-46`), so out-of-region hits never get stored.
+
+## Usage
+
+The emulator must be running with the seed loaded (Firestore on `127.0.0.1:8081`).
+
+```bash
+# Dry run — free-only, no writes, prints per-territory method + a summary line.
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8081 node tools/geocode-territories/backfill.mjs --dry-run --limit 30
+
+# Full backfill of the not-yet-geocoded territories, with Google fallback for the ~50% Nominatim misses.
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8081 GOOGLE_MAPS_API_KEY=... node tools/geocode-territories/backfill.mjs --only-missing
+```
+
+## Flags
+
+| Flag | Effect |
+| --- | --- |
+| `--dry-run` | Never writes. Prints the resolved method per territory and a final summary (located/failed counts + method breakdown). |
+| `--limit N` | Only process the first `N` territories. |
+| `--only-missing` | Skip territories that already have a `geo` coordinate (also re-tries prior `failed` ones, which have no `geo`). |
+
+## Writes (non-dry-run)
+
+Each located territory gets, via a merge write:
+
+- `geo` — a Firestore `GeoPoint(lat, lng)`.
+- `geoStatus` — `'ok'` (url/Google), `'approx'` (Nominatim/CEP), or `'failed'`.
+- `geocodedAt` — a Firestore `Timestamp`.
+
+## Notes
+
+- **Firebase Admin** is loaded from the main tree's `functions/ministry-maps` install
+  (worktrees don't have their own `functions/node_modules`).
+- **Politeness:** ≥1.1s between any two Nominatim/Google calls; User-Agent
+  `kingdom-apps-territory-geocoder/0.1`.
+- **The Google API key is never committed.** Read it from the environment only — it
+  lives in the `~/dev/matinhoviagens` env. Pass it inline as `GOOGLE_MAPS_API_KEY=...`
+  when running the paid fallback; without it the script stays 100% free.
+- This is a one-time backfill against the **local emulator seed** — it does not touch
+  production and it never commits the seed (PII).

--- a/tools/geocode-territories/backfill.mjs
+++ b/tools/geocode-territories/backfill.mjs
@@ -1,0 +1,209 @@
+// One-time territory geocoder backfill (local dev tool).
+//
+// Runs a free-first waterfall to attach a cached `geo` coordinate to each
+// territory in the local Firestore emulator:
+//   resolve mapsLink -> coords-from-url
+//     -> Nominatim(CEP) -> Nominatim(clean resolved address) -> Nominatim(stored address + city)
+//     -> (optional) Google Geocoding  [only when GOOGLE_MAPS_API_KEY is set]
+//     -> failed
+//
+// Never commits or reads the real seed. Never hard-codes an API key - the Google
+// key is read from the environment only. See README.md for usage + flags.
+
+import admin from '/Users/matheus/dev/kingdom-apps/functions/ministry-maps/node_modules/firebase-admin/lib/index.js';
+
+// --- Emulator connection ---------------------------------------------------
+process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8081';
+admin.initializeApp({ projectId: 'du-ministry-maps' });
+const db = admin.firestore();
+
+// --- Flags -----------------------------------------------------------------
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const ONLY_MISSING = args.includes('--only-missing');
+const limitFlagIdx = args.findIndex((a) => a === '--limit');
+const LIMIT = limitFlagIdx >= 0 ? Number(args[limitFlagIdx + 1]) : null;
+const GOOGLE_KEY = process.env.GOOGLE_MAPS_API_KEY || null;
+
+// --- Config ----------------------------------------------------------------
+const UA_BOT = 'curl/8.4.0';                               // resolving Google short links
+const UA_GEOCODER = 'kingdom-apps-territory-geocoder/0.1'; // Nominatim/Google politeness UA
+const MIN_GAP_MS = 1100;                                   // >= 1.1s between Nominatim/Google calls
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Shared throttle: ensure >= MIN_GAP_MS between any two geocoding-provider calls.
+let lastGeoCallAt = 0;
+async function throttleGeoCall() {
+  const wait = MIN_GAP_MS - (Date.now() - lastGeoCallAt);
+  if (wait > 0) await sleep(wait);
+  lastGeoCallAt = Date.now();
+}
+
+// --- Region guard (matches the validated spike: lat[-24,-21] / lng[-48,-46]) ---
+// Rejects the constant Google viewport-center (-22.742162,-47.284224) that leaks
+// into non-place pages, and clamps to the tri-city bounding box.
+const VIEWPORT_CENTER = { lat: -22.742162, lng: -47.284224 };
+const BBOX = { latMin: -24, latMax: -21, lngMin: -48, lngMax: -46 };
+function isInRegion(c) {
+  if (!c || !Number.isFinite(c.lat) || !Number.isFinite(c.lng)) return false;
+  const near =
+    Math.abs(c.lat - VIEWPORT_CENTER.lat) < 1e-3 &&
+    Math.abs(c.lng - VIEWPORT_CENTER.lng) < 1e-3;
+  return (
+    !near &&
+    c.lat > BBOX.latMin && c.lat < BBOX.latMax &&
+    c.lng > BBOX.lngMin && c.lng < BBOX.lngMax
+  );
+}
+
+// --- Parse helpers (inline copy of geocode-parse.ts - .mjs can't import the TS) ---
+function coordsFromUrl(u) {
+  const at = u.match(/@(-?\d{1,2}\.\d{4,}),(-?\d{1,3}\.\d{4,})/);
+  if (at) return { lat: +at[1], lng: +at[2] };
+  const bang = u.match(/!3d(-?\d{1,2}\.\d{4,})!4d(-?\d{1,3}\.\d{4,})/);
+  if (bang) return { lat: +bang[1], lng: +bang[2] };
+  return null;
+}
+function cleanAddrFromUrl(u) {
+  const m = u.match(/\/place\/([^/@]+)/);
+  if (!m) return null;
+  let s = m[1];
+  for (let i = 0; i < 2; i++) {
+    try { s = decodeURIComponent(s); } catch { break; }
+  }
+  return s.replace(/\+/g, ' ').trim() || null;
+}
+const cepOf = (s) => (s ? (String(s).match(/\b\d{5}-?\d{3}\b/) || [null])[0] : null);
+
+// --- Providers -------------------------------------------------------------
+async function nominatim(q) {
+  await throttleGeoCall();
+  const url = `https://nominatim.openstreetmap.org/search?format=jsonv2&limit=1&countrycodes=br&q=${encodeURIComponent(q)}`;
+  const res = await fetch(url, { headers: { 'User-Agent': UA_GEOCODER } });
+  const arr = await res.json().catch(() => []);
+  if (Array.isArray(arr) && arr.length) return { lat: +arr[0].lat, lng: +arr[0].lon };
+  return null;
+}
+
+async function googleGeocode(address) {
+  if (!GOOGLE_KEY || !address) return null;
+  await throttleGeoCall();
+  const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&region=br&key=${GOOGLE_KEY}`;
+  const res = await fetch(url, { headers: { 'User-Agent': UA_GEOCODER } });
+  const body = await res.json().catch(() => null);
+  const loc = body?.results?.[0]?.geometry?.location;
+  if (loc && Number.isFinite(loc.lat) && Number.isFinite(loc.lng)) {
+    return { lat: loc.lat, lng: loc.lng };
+  }
+  return null;
+}
+
+// method -> geoStatus: 'ok' for url/google, 'approx' for nominatim (cep/clean/stored), 'failed' otherwise.
+function statusFor(method) {
+  if (method === 'url' || method === 'google') return 'ok';
+  if (method === 'cep' || method === 'clean-addr' || method === 'stored-addr') return 'approx';
+  return 'failed';
+}
+
+// --- Waterfall for a single territory --------------------------------------
+async function locate(t) {
+  const storedAddr = (t.address || '').replace(/\t/g, ' ').trim();
+  const city = t.city || '';
+  let coords = null;
+  let method = 'failed';
+  let cleanAddr = null;
+
+  // 1) Resolve mapsLink and read coords straight off the resolved URL.
+  const rawLink = t.mapsLink && String(t.mapsLink).trim();
+  if (rawLink) {
+    const link = rawLink.match(/https?:\/\/\S+/)?.[0] ?? rawLink;
+    try {
+      const res = await fetch(link, { redirect: 'follow', headers: { 'User-Agent': UA_BOT, 'Accept-Language': 'en' } });
+      const finalUrl = res.url;
+      cleanAddr = cleanAddrFromUrl(finalUrl);
+      const urlCoords = coordsFromUrl(finalUrl);
+      if (isInRegion(urlCoords)) { coords = urlCoords; method = 'url'; }
+    } catch (e) {
+      // network/redirect failure - fall through to address-based lookups
+    }
+  }
+
+  // 2) Nominatim(CEP) -> Nominatim(clean resolved address) -> Nominatim(stored address + city)
+  if (!coords) {
+    const cep = cepOf(cleanAddr) || cepOf(storedAddr);
+    if (cep) {
+      const c = await nominatim(`${cep}, Brasil`);
+      if (isInRegion(c)) { coords = c; method = 'cep'; }
+    }
+  }
+  if (!coords && cleanAddr) {
+    const c = await nominatim(cleanAddr);
+    if (isInRegion(c)) { coords = c; method = 'clean-addr'; }
+  }
+  if (!coords && (storedAddr || city)) {
+    const c = await nominatim(`${storedAddr}, ${city}, SP`);
+    if (isInRegion(c)) { coords = c; method = 'stored-addr'; }
+  }
+
+  // 3) Google fallback (only when a key is present in the environment).
+  if (!coords && GOOGLE_KEY) {
+    const address = cleanAddr || (storedAddr ? `${storedAddr}, ${city}, SP` : null);
+    const c = await googleGeocode(address);
+    if (isInRegion(c)) { coords = c; method = 'google'; }
+  }
+
+  return { coords, method, cleanAddr, storedAddr };
+}
+
+// --- Main ------------------------------------------------------------------
+async function main() {
+  const snap = await db.collection('territories').get();
+  let docs = snap.docs;
+  if (ONLY_MISSING) docs = docs.filter((d) => d.data().geo == null);
+  if (LIMIT && LIMIT > 0) docs = docs.slice(0, LIMIT);
+
+  const counts = { url: 0, cep: 0, 'clean-addr': 0, 'stored-addr': 0, google: 0, failed: 0 };
+  let located = 0;
+
+  console.log(
+    `Geocoding ${docs.length} territories | dry-run=${DRY_RUN} only-missing=${ONLY_MISSING} google=${GOOGLE_KEY ? 'on' : 'off'}${LIMIT ? ` limit=${LIMIT}` : ''}`
+  );
+
+  for (const d of docs) {
+    const t = d.data();
+    const { coords, method, cleanAddr, storedAddr } = await locate(t);
+    const status = statusFor(method);
+    const good = status !== 'failed';
+    if (good) located++;
+    counts[method] = (counts[method] || 0) + 1;
+
+    const label = (t.note || storedAddr || d.id).split('\n')[0].slice(0, 14).padEnd(14);
+    const coordStr = coords ? `${coords.lat.toFixed(5)},${coords.lng.toFixed(5)}` : '(none)';
+    console.log(
+      `${good ? 'OK ' : 'XX '} ${label} ${method.padEnd(12)} ${status.padEnd(7)} ${coordStr.padEnd(20)} | ${(cleanAddr || storedAddr).slice(0, 44)}`
+    );
+
+    if (!DRY_RUN) {
+      const update = { geoStatus: status, geocodedAt: admin.firestore.Timestamp.now() };
+      if (coords) update.geo = new admin.firestore.GeoPoint(coords.lat, coords.lng);
+      await d.ref.set(update, { merge: true });
+    }
+  }
+
+  const breakdown = Object.entries(counts)
+    .filter(([, n]) => n > 0)
+    .map(([k, n]) => `${k}:${n}`)
+    .join(' ');
+  console.log(
+    `\n=== ${located}/${docs.length} located | failed:${counts.failed} | ${breakdown} ===` +
+    (DRY_RUN ? ' (dry-run: no writes)' : ' (written)')
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## What this adds

The Designar Território page can now plan the whole assignment for you. You put in how many people and cars you have, pick the territories (or let it pick), and it:

- orders them by distance, starting from whatever has gone the longest without a visit,
- forms the working pairs/trios and splits them across the cars, capped at 5 people per car,
- and shares each car's list, in visiting order, to WhatsApp.

"Distribuir automaticamente" selects the most overdue territories in the city you're viewing and splits them in one click. "Economizar carros" switches between packing into the fewest cars and spreading the groups across all of them.

Before this, assignments were planned by eyeballing the map, guessing which territories were near each other and which had been sitting untouched. Now that ordering is done for you and each group gets a tight, in-order route.

## Geocoding (and the one cost)

Sorting by distance needs coordinates, and territories only had a Google Maps link. So there's now a cached `geo` field on the territory model and a one-off tool under `tools/geocode-territories` that fills it and writes it back to Firestore. It resolves each territory the cheapest way first: pulling the coordinates out of the stored maps link, then OpenStreetMap Nominatim on the address/CEP, and only falling back to Google's Geocoding API when nothing else resolves.

- Nominatim does most of the work and is free.
- Google Geocoding is fallback only, and runs only during the one-time backfill. Backfilling all 229 current territories cost about $0.51. The key is read from an env var when you run the tool; it isn't committed, and the app never geocodes at runtime, it just reads the cached coordinates.

The routing itself is exact for small clusters (Held-Karp up to 15 stops) and nearest-neighbor + 2-opt above that, with a balanced split so no group ends up with a lopsided route. That part is ported from the routing code I already had in matinhoviagens.

## Testing

Unit tests cover the maps-link parsing, pairing, capacity, the route optimizer, and the car split (the split has a 5000-case fuzz test on its invariants). I also ran the full flow against the Firebase emulator end to end: manual and automatic distribute, the economize toggle, the 5-per-car cap, sharing a car, and checking that the designation is saved with its territories in the right order.

## Notes

- The `geo` field is additive: existing territories are untouched, and the backfill is safe to re-run since it skips anything already geocoded.
- 5 per car is a hard cap; if there aren't enough cars for everyone it warns instead of overfilling.
